### PR TITLE
feat: admin user management and realistic seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,28 @@ En XAMPP/MAMP el usuario `root` suele ir sin contraseña → deja `DB_PASSWORD` 
 - Vista bajo stock (productos con stock < stock_minimo).
 - Validación de formularios con express-validator y feedback visual (Bootstrap).
 
+## Datos de ejemplo
+Incluye un script con usuarios, categorías, proveedores, localizaciones y más de veinte productos.
+Importar:
+
+```
+mysql -u root -p inventario < db/seeds/20250901_semillas_realistas.sql
+```
+
+Contraseñas:
+- `admin123` para administradores.
+- `usuario123` para operadores.
+
+## Gestión de usuarios (solo admin)
+- El menú **Usuarios** sólo aparece para rol administrador.
+- Permite listar, crear, editar, eliminar y cambiar contraseñas.
+- Validaciones: email válido, rol existente y contraseña mínima de 8 caracteres.
+
+## Stock vs Stock mínimo – guía de uso
+- Listados muestran columnas separadas de stock y stock mínimo.
+- Si el stock es menor que el mínimo se marca la fila con `table-warning` y badge "Bajo stock".
+- Formularios de productos incluyen ayuda para cada campo de stock.
+
 ## Política de comentarios ("supercomentado")
 - `src/app.js` y `src/config/db.js`: comentados línea a línea explicando qué hace cada instrucción y por qué.
 - Resto de archivos (`routes/`, `controllers/`, `validators/`, `views/`): comentarios por bloques cubriendo propósito, entradas/salidas, validaciones y manejo de errores.
@@ -153,10 +175,33 @@ Nunca subas `.env` al repo.
 Cambia `SESSION_SECRET` en producción y activa `cookie.secure` detrás de HTTPS.
 Revisa inputs de formularios con express-validator (servidor) además de validación en cliente.
 
+### Errores al importar seeds
+- Confirma que la base `inventario` existe y el esquema está aplicado.
+- Ejecuta la migración `db/migrations/20250901_1200_add_campos_usuarios.sql` antes de importar si hay columnas faltantes.
+- El script de semillas trunca tablas, por lo que cualquier dato previo se pierde.
+
+## Pruebas manuales
+1. Importar seeds: `mysql -u root -p inventario < db/seeds/20250901_semillas_realistas.sql`.
+2. Login admin: `laura.gonzalez@tienda.local` / `admin123`.
+3. Usuarios: crear un operador, editarlo y eliminarlo.
+4. Productos: crear uno con stock/stock mínimo y observar badge "Bajo stock" en el listado.
+5. Bajo stock: visitar `/productos/bajo-stock` y comprobar resultados.
+6. Regresión básica: `/`, `/login`, `/health`, `/resources` y `/db-health` responden 200.
+
+## Resumen de cambios
+- Semillas realistas con múltiples entidades y contraseñas bcrypt.
+- CRUD de usuarios protegido exclusivamente para administradores.
+- Interfaz de productos con columnas separadas de stock y stock mínimo.
+
 ## Changelog
 ### 2025-08-26
 - Validación de variables de entorno y carga temprana de `dotenv`.
 - Log "DB OK" al iniciar la conexión y mensajes de error claros.
 - Ruta `/db-health` para comprobar la base de datos.
 - README completado y `.env.example` actualizado.
+
+### 2025-09-01
+- Script `20250901_semillas_realistas.sql` con datos de ejemplo realistas.
+- Rutas y vistas para gestionar usuarios solo por administradores.
+- Listados de productos con columnas de stock y stock mínimo y badges de bajo stock.
 

--- a/db/migrations/20250901_1200_add_campos_usuarios.sql
+++ b/db/migrations/20250901_1200_add_campos_usuarios.sql
@@ -1,0 +1,4 @@
+USE inventario;
+ALTER TABLE usuarios
+  ADD apellidos VARCHAR(100) NOT NULL AFTER nombre,
+  ADD telefono VARCHAR(20) AFTER email;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -16,7 +16,9 @@ CREATE TABLE roles (
 CREATE TABLE usuarios (
   id INT AUTO_INCREMENT PRIMARY KEY,
   nombre VARCHAR(100) NOT NULL,
+  apellidos VARCHAR(100) NOT NULL,
   email VARCHAR(100) NOT NULL UNIQUE,
+  telefono VARCHAR(20),
   password VARCHAR(100) NOT NULL,
   rol_id INT NOT NULL,
   FOREIGN KEY (rol_id) REFERENCES roles(id)
@@ -77,8 +79,8 @@ CREATE TABLE producto_proveedor (
 INSERT INTO roles (nombre) VALUES ('admin'), ('operador');
 
 -- Hash creado con bcrypt para la contraseña 'admin123'
-INSERT INTO usuarios (nombre, email, password, rol_id) VALUES
-('Admin', 'admin@demo.local', '$2a$12$pdEnaSyJUF53FPOfCwJ2S.8s9LT2Ozft9smeZlRJ1o0YmRvDbQ3Ju', 1);
+INSERT INTO usuarios (nombre, apellidos, email, telefono, password, rol_id) VALUES
+('Admin', 'Principal', 'admin@demo.local', NULL, '$2a$12$pdEnaSyJUF53FPOfCwJ2S.8s9LT2Ozft9smeZlRJ1o0YmRvDbQ3Ju', 1);
 
 INSERT INTO localizaciones (nombre) VALUES
 ('Almacén A'),

--- a/db/seeds/20250901_semillas_realistas.sql
+++ b/db/seeds/20250901_semillas_realistas.sql
@@ -1,0 +1,111 @@
+USE inventario;
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE producto_proveedor;
+TRUNCATE TABLE producto_categoria;
+TRUNCATE TABLE productos;
+TRUNCATE TABLE proveedores;
+TRUNCATE TABLE categorias;
+TRUNCATE TABLE localizaciones;
+TRUNCATE TABLE usuarios;
+TRUNCATE TABLE roles;
+SET FOREIGN_KEY_CHECKS=1;
+
+INSERT INTO roles (id, nombre) VALUES
+(1,'admin'),(2,'operador');
+
+INSERT INTO usuarios (nombre, apellidos, email, telefono, password, rol_id) VALUES
+('Laura','González','laura.gonzalez@tienda.local','600111222','$2a$10$L1YolqS1AzMFNJfNpQYWeeKP1dG/xL3I0znXTWI3M4cOBrYPngtp2',1),
+('Carlos','Pérez','carlos.perez@tienda.local','600333444','$2a$10$L1YolqS1AzMFNJfNpQYWeeKP1dG/xL3I0znXTWI3M4cOBrYPngtp2',1),
+('Marta','Jiménez','marta.jimenez@tienda.local','600555666','$2a$10$XAJcRoEKxKZDuifmXYYtd.KkCqc4HS3zIbGVx1/ATrTUnCeKV4IUi',2),
+('Javier','Ruiz','javier.ruiz@tienda.local','600777888','$2a$10$XAJcRoEKxKZDuifmXYYtd.KkCqc4HS3zIbGVx1/ATrTUnCeKV4IUi',2),
+('Lucía','López','lucia.lopez@tienda.local','600111333','$2a$10$XAJcRoEKxKZDuifmXYYtd.KkCqc4HS3zIbGVx1/ATrTUnCeKV4IUi',2),
+('Sergio','Martín','sergio.martin@tienda.local','600222444','$2a$10$XAJcRoEKxKZDuifmXYYtd.KkCqc4HS3zIbGVx1/ATrTUnCeKV4IUi',2),
+('Ana','Navarro','ana.navarro@tienda.local','600333555','$2a$10$XAJcRoEKxKZDuifmXYYtd.KkCqc4HS3zIbGVx1/ATrTUnCeKV4IUi',2),
+('Diego','Romero','diego.romero@tienda.local','600444666','$2a$10$XAJcRoEKxKZDuifmXYYtd.KkCqc4HS3zIbGVx1/ATrTUnCeKV4IUi',2);
+
+INSERT INTO categorias (nombre) VALUES
+('Herramientas'),('Pintura'),('Fontanería'),('Electricidad'),('Informática'),('Limpieza'),('Ferretería'),('Jardinería'),('Papelería'),('Pequeño electrodoméstico');
+
+INSERT INTO proveedores (nombre) VALUES
+('Suministros López'),('Ferretería El Tornillo'),('Electro Reus'),('Papeles Martínez'),('Distribuciones Romero'),('TecnoPiso'),('BricoTarraco'),('Almacenes García');
+
+INSERT INTO localizaciones (nombre) VALUES
+('Almacén Central'),('Pasillo A'),('Pasillo B'),('Estantería 1'),('Estantería 2'),('Mostrador'),('Sótano'),('Almacén Secundario');
+
+INSERT INTO productos (nombre, descripcion, precio, stock, stock_minimo, localizacion_id) VALUES
+('Martillo de uña','',12.50,5,10,2),
+('Destornillador plano','',3.20,20,15,2),
+('Taladro percutor 800W','',85.00,2,5,1),
+('Pintura blanca 15L','',25.00,8,10,3),
+('Cable eléctrico 1.5mm 100m','',40.00,30,20,3),
+('Tornillos 4x40 caja 100u','',5.00,50,40,2),
+('Fregona microfibra','',6.00,3,5,6),
+('Papel A4 500 hojas','',4.50,100,50,4),
+('Ratón óptico USB','',9.99,4,10,6),
+('Regleta 6 tomas con interruptor','',12.00,6,8,6),
+('Bombilla LED E27 9W','',2.50,25,20,3),
+('Llave inglesa ajustable','',14.00,7,10,2),
+('Tubo PVC 20mm 2m','',3.80,12,15,3),
+('Guantes de látex caja 100u','',7.50,60,30,5),
+('Manguera de jardín 15m','',18.00,4,5,8),
+('Cinta aislante negra','',1.20,15,10,3),
+('Cepillo de barrer','',3.00,2,5,6),
+('Ordenador portátil 15"','',600.00,1,1,6),
+('Aspiradora 1200W','',80.00,0,2,6),
+('Grapadora de escritorio','',8.00,25,20,4),
+('Lámpara de mesa LED','',20.00,3,5,6),
+('Detergente multiusos 5L','',9.00,10,8,5),
+('Alicates universales','',11.00,9,10,2),
+('USB 32GB','',6.00,40,20,6);
+
+INSERT INTO producto_categoria (producto_id, categoria_id) VALUES
+(1,1),(1,7),
+(2,1),(2,7),
+(3,1),(3,10),
+(4,2),
+(5,4),
+(6,7),
+(7,6),
+(8,9),
+(9,5),
+(10,4),(10,10),
+(11,4),
+(12,1),(12,7),
+(13,3),
+(14,6),
+(15,8),
+(16,4),(16,7),
+(17,6),
+(18,5),
+(19,10),
+(20,9),
+(21,4),(21,5),
+(22,6),
+(23,1),(23,7),
+(24,5),(24,9);
+
+INSERT INTO producto_proveedor (producto_id, proveedor_id) VALUES
+(1,1),(1,2),
+(2,2),
+(3,2),(3,3),
+(4,5),(4,6),
+(5,3),
+(6,2),
+(7,8),
+(8,4),
+(9,3),
+(10,3),
+(11,3),
+(12,1),
+(13,5),
+(14,8),
+(15,8),
+(16,3),(16,2),
+(17,8),
+(18,3),
+(19,3),
+(20,4),
+(21,3),
+(22,8),
+(23,1),(23,2),
+(24,3),(24,4);

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ const productosRoutes = require('./routes/productos.routes');     // Conjunto de
 const categoriasRoutes = require('./routes/categorias.routes');   // Conjunto de rutas CRUD de categorías
 const proveedoresRoutes = require('./routes/proveedores.routes'); // Conjunto de rutas CRUD de proveedores
 const localizacionesRoutes = require('./routes/localizaciones.routes'); // Conjunto de rutas CRUD de localizaciones
+const usuariosRoutes = require('./routes/usuarios.routes');     // Conjunto de rutas CRUD de usuarios
 const db = require('./config/db');                                // Pool de conexiones MySQL reutilizable
 
 const app = express();                           // Crea la instancia de Express
@@ -67,6 +68,7 @@ app.use('/productos', requireAuth, productosRoutes);       // CRUD de productos 
 app.use('/categorias', requireAuth, categoriasRoutes);    // CRUD de categorías (protección por login)
 app.use('/proveedores', requireAuth, proveedoresRoutes);  // CRUD de proveedores (protección por login)
 app.use('/localizaciones', requireAuth, localizacionesRoutes); // CRUD de localizaciones (protección por login)
+app.use('/usuarios', requireAuth, requireRole('admin'), usuariosRoutes); // CRUD de usuarios (solo admin)
 
 app.listen(PORT, () => {                          // Arranca el servidor
   console.log(`Servidor escuchando en http://localhost:${PORT}`); // Mensaje de inicio en consola

--- a/src/controllers/usuarios.controller.js
+++ b/src/controllers/usuarios.controller.js
@@ -1,0 +1,84 @@
+const pool = require('../config/db');
+const bcrypt = require('bcryptjs');
+const { validationResult } = require('express-validator');
+
+// Listar usuarios con su rol
+exports.list = async (req, res) => {
+  const [rows] = await pool.query('SELECT u.id, u.nombre, u.apellidos, u.email, r.nombre AS rol FROM usuarios u JOIN roles r ON u.rol_id = r.id');
+  const message = req.session.message;
+  delete req.session.message;
+  res.render('pages/usuarios/list', { usuarios: rows, message });
+};
+
+// Mostrar formulario para crear o editar
+exports.form = async (req, res) => {
+  const [roles] = await pool.query('SELECT * FROM roles');
+  let usuario = null;
+  if (req.params.id) {
+    const [rows] = await pool.query('SELECT * FROM usuarios WHERE id=?', [req.params.id]);
+    if (rows.length) usuario = rows[0];
+  }
+  const message = req.session.message;
+  delete req.session.message;
+  res.render('pages/usuarios/form', { usuario, roles, errors: [], message });
+};
+
+// Crear usuario nuevo
+exports.create = async (req, res) => {
+  const errors = validationResult(req);
+  const [roles] = await pool.query('SELECT * FROM roles');
+  if (!errors.isEmpty()) {
+    return res.render('pages/usuarios/form', { usuario: null, roles, errors: errors.array(), message: null });
+  }
+  const { nombre, apellidos, email, telefono, rol_id, password } = req.body;
+  const hash = await bcrypt.hash(password, 10);
+  await pool.query('INSERT INTO usuarios (nombre, apellidos, email, telefono, password, rol_id) VALUES (?,?,?,?,?,?)',
+    [nombre, apellidos, email, telefono, hash, rol_id]);
+  req.session.message = { type: 'success', text: 'Usuario creado' };
+  res.redirect('/usuarios');
+};
+
+// Actualizar usuario existente (sin contraseña)
+exports.update = async (req, res) => {
+  const errors = validationResult(req);
+  const id = req.params.id;
+  const [roles] = await pool.query('SELECT * FROM roles');
+  if (!errors.isEmpty()) {
+    const [rows] = await pool.query('SELECT * FROM usuarios WHERE id=?', [id]);
+    return res.render('pages/usuarios/form', { usuario: rows[0], roles, errors: errors.array(), message: null });
+  }
+  const { nombre, apellidos, email, telefono, rol_id } = req.body;
+  await pool.query('UPDATE usuarios SET nombre=?, apellidos=?, email=?, telefono=?, rol_id=? WHERE id=?',
+    [nombre, apellidos, email, telefono, rol_id, id]);
+  req.session.message = { type: 'success', text: 'Usuario actualizado' };
+  res.redirect('/usuarios');
+};
+
+// Eliminar usuario
+exports.remove = async (req, res) => {
+  await pool.query('DELETE FROM usuarios WHERE id=?', [req.params.id]);
+  req.session.message = { type: 'success', text: 'Usuario eliminado' };
+  res.redirect('/usuarios');
+};
+
+// Formulario para cambiar contraseña
+exports.showChangePassword = async (req, res) => {
+  const [rows] = await pool.query('SELECT id, nombre, apellidos FROM usuarios WHERE id=?', [req.params.id]);
+  if (!rows.length) return res.redirect('/usuarios');
+  res.render('pages/usuarios/change-password', { usuario: rows[0], errors: [], message: null });
+};
+
+// Actualizar contraseña
+exports.changePassword = async (req, res) => {
+  const errors = validationResult(req);
+  const id = req.params.id;
+  const [rows] = await pool.query('SELECT id, nombre, apellidos FROM usuarios WHERE id=?', [id]);
+  if (!rows.length) return res.redirect('/usuarios');
+  if (!errors.isEmpty()) {
+    return res.render('pages/usuarios/change-password', { usuario: rows[0], errors: errors.array(), message: null });
+  }
+  const hash = await bcrypt.hash(req.body.password, 10);
+  await pool.query('UPDATE usuarios SET password=? WHERE id=?', [hash, id]);
+  req.session.message = { type: 'success', text: 'Contraseña actualizada' };
+  res.redirect('/usuarios');
+};

--- a/src/routes/usuarios.routes.js
+++ b/src/routes/usuarios.routes.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/usuarios.controller');
+const { createUserValidator, updateUserValidator, passwordValidator } = require('../validators/usuarios.validators');
+
+// GET /usuarios - listado de usuarios
+router.get('/', controller.list); // Listado
+
+// GET /usuarios/nuevo - formulario de creación
+router.get('/nuevo', controller.form); // Form crear
+
+// POST /usuarios/nuevo - guardar usuario nuevo
+router.post('/nuevo', createUserValidator, controller.create); // Guardar nuevo
+
+// GET /usuarios/:id/editar - formulario de edición
+router.get('/:id/editar', controller.form); // Form editar
+
+// POST /usuarios/:id/editar - actualizar datos
+router.post('/:id/editar', updateUserValidator, controller.update); // Actualizar
+
+// GET /usuarios/:id/eliminar - borrar usuario
+router.get('/:id/eliminar', controller.remove); // Eliminar
+
+// GET /usuarios/:id/cambiar-password - formulario cambio contraseña
+router.get('/:id/cambiar-password', controller.showChangePassword); // Form password
+
+// POST /usuarios/:id/cambiar-password - actualizar contraseña
+router.post('/:id/cambiar-password', passwordValidator, controller.changePassword); // Actualizar password
+
+module.exports = router;

--- a/src/validators/usuarios.validators.js
+++ b/src/validators/usuarios.validators.js
@@ -1,0 +1,29 @@
+const { body } = require('express-validator');
+const pool = require('../config/db');
+
+// Campos comunes para crear y editar
+const baseFields = [
+  body('nombre').notEmpty().withMessage('Nombre es obligatorio'),
+  body('apellidos').notEmpty().withMessage('Apellidos es obligatorio'),
+  body('email').isEmail().withMessage('Email inválido'),
+  body('telefono').notEmpty().withMessage('Teléfono es obligatorio'),
+  body('rol_id').custom(async value => {
+    const [rows] = await pool.query('SELECT id FROM roles WHERE id=?', [value]);
+    if (!rows.length) throw new Error('Rol inválido');
+    return true;
+  })
+];
+
+// Validaciones para creación
+exports.createUserValidator = [
+  ...baseFields,
+  body('password').isLength({ min: 8 }).withMessage('Contraseña mínima de 8 caracteres')
+];
+
+// Validaciones para edición
+exports.updateUserValidator = baseFields;
+
+// Validación para cambiar contraseña
+exports.passwordValidator = [
+  body('password').isLength({ min: 8 }).withMessage('Contraseña mínima de 8 caracteres')
+];

--- a/src/views/pages/productos/form.ejs
+++ b/src/views/pages/productos/form.ejs
@@ -16,10 +16,12 @@
     <div class="col-md-4 mb-3">
       <label class="form-label">Stock</label>
       <input type="number" name="stock" class="form-control" value="<%= producto ? producto.stock : '' %>">
+      <div class="form-text">Cantidad actual disponible</div>
     </div>
     <div class="col-md-4 mb-3">
       <label class="form-label">Stock mínimo</label>
       <input type="number" name="stock_minimo" class="form-control" value="<%= producto ? producto.stock_minimo : '' %>">
+      <div class="form-text">Umbral mínimo antes de reponer</div>
     </div>
   </div>
   <div class="mb-3">

--- a/src/views/pages/productos/list.ejs
+++ b/src/views/pages/productos/list.ejs
@@ -7,6 +7,7 @@
       <th>Nombre</th>
       <th>Precio</th>
       <th>Stock</th>
+      <th>Stock mínimo</th>
       <th>Localización</th>
       <th>Acciones</th>
     </tr>
@@ -17,7 +18,8 @@
         <td><%= p.id %></td>
         <td><%= p.nombre %></td>
         <td><%= p.precio %></td>
-        <td><%= p.stock %> / <%= p.stock_minimo %></td>
+        <td><%= p.stock %> <% if (p.stock < p.stock_minimo) { %><span class="badge bg-danger">Bajo stock</span><% } %></td>
+        <td><%= p.stock_minimo %></td>
         <td><%= p.localizacion %></td>
         <td>
           <a href="/productos/<%= p.id %>" class="btn btn-sm btn-primary"><i class='bx bx-show'></i></a>

--- a/src/views/pages/usuarios/change-password.ejs
+++ b/src/views/pages/usuarios/change-password.ejs
@@ -1,0 +1,16 @@
+<h1>Cambiar contraseña de <%= usuario.nombre %> <%= usuario.apellidos %></h1>
+<form action="/usuarios/<%= usuario.id %>/cambiar-password" method="POST">
+  <div class="mb-3">
+    <label class="form-label">Nueva contraseña</label>
+    <input type="password" name="password" class="form-control">
+    <div class="form-text">Mínimo 8 caracteres</div>
+  </div>
+  <% if (errors.length) { %>
+    <div class="alert alert-danger">
+      <ul class="mb-0">
+        <% errors.forEach(e => { %><li><%= e.msg %></li><% }) %>
+      </ul>
+    </div>
+  <% } %>
+  <button class="btn btn-primary">Actualizar</button>
+</form>

--- a/src/views/pages/usuarios/form.ejs
+++ b/src/views/pages/usuarios/form.ejs
@@ -1,0 +1,47 @@
+<h1><%= usuario ? 'Editar' : 'Nuevo' %> usuario</h1>
+<form action="<%= usuario ? '/usuarios/' + usuario.id + '/editar' : '/usuarios/nuevo' %>" method="POST">
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Nombre</label>
+      <input type="text" name="nombre" class="form-control" value="<%= usuario ? usuario.nombre : '' %>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Apellidos</label>
+      <input type="text" name="apellidos" class="form-control" value="<%= usuario ? usuario.apellidos : '' %>">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Email</label>
+      <input type="email" name="email" class="form-control" value="<%= usuario ? usuario.email : '' %>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Teléfono</label>
+      <input type="text" name="telefono" class="form-control" value="<%= usuario ? usuario.telefono : '' %>">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Rol</label>
+      <select name="rol_id" class="form-select">
+        <% roles.forEach(r => { %>
+          <option value="<%= r.id %>" <%= usuario && usuario.rol_id == r.id ? 'selected' : '' %>><%= r.nombre %></option>
+        <% }) %>
+      </select>
+    </div>
+    <% if (!usuario) { %>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Contraseña</label>
+      <input type="password" name="password" class="form-control">
+    </div>
+    <% } %>
+  </div>
+  <% if (errors.length) { %>
+    <div class="alert alert-danger">
+      <ul class="mb-0">
+        <% errors.forEach(e => { %><li><%= e.msg %></li><% }) %>
+      </ul>
+    </div>
+  <% } %>
+  <button class="btn btn-primary">Guardar</button>
+</form>

--- a/src/views/pages/usuarios/list.ejs
+++ b/src/views/pages/usuarios/list.ejs
@@ -1,0 +1,31 @@
+<h1>Usuarios</h1>
+<a href="/usuarios/nuevo" class="btn btn-success mb-2">Nuevo</a>
+<% if (message) { %>
+  <div class="alert alert-<%= message.type %>"><%= message.text %></div>
+<% } %>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Nombre</th>
+      <th>Email</th>
+      <th>Rol</th>
+      <th>Acciones</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% usuarios.forEach(u => { %>
+      <tr>
+        <td><%= u.id %></td>
+        <td><%= u.nombre %> <%= u.apellidos %></td>
+        <td><%= u.email %></td>
+        <td><%= u.rol %></td>
+        <td>
+          <a href="/usuarios/<%= u.id %>/editar" class="btn btn-sm btn-warning"><i class='bx bx-edit'></i></a>
+          <a href="/usuarios/<%= u.id %>/cambiar-password" class="btn btn-sm btn-secondary"><i class='bx bx-key'></i></a>
+          <a href="/usuarios/<%= u.id %>/eliminar" class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar?')"><i class='bx bx-trash'></i></a>
+        </td>
+      </tr>
+    <% }) %>
+  </tbody>
+</table>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -11,6 +11,7 @@
             <li class="nav-item"><a class="nav-link" href="/proveedores">Proveedores</a></li>
             <li class="nav-item"><a class="nav-link" href="/localizaciones">Localizaciones</a></li>
             <li class="nav-item"><a class="nav-link" href="/productos/bajo-stock">Bajo stock</a></li>
+            <% if (userRole === 'admin') { %><li class="nav-item"><a class="nav-link" href="/usuarios">Usuarios</a></li><% } %>
           <% } %>
         </ul>
         <ul class="navbar-nav">


### PR DESCRIPTION
## Summary
- seed database with realistic users, categories, providers, locations and products
- add admin-only user CRUD with validation and password hashing
- separate product stock and minimum stock with badges for low levels

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5d248bdec832a9cec9af9487c4f3d