### PR TITLE
feat: filtros en listados y navegación returnTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ Contraseñas:
 - Si el stock es menor que el mínimo se marca la fila con `table-warning` y badge "Bajo stock".
 - Formularios de productos incluyen ayuda para cada campo de stock.
 
+## Panel de inventario
+Las tarjetas del panel muestran conteos generales de productos, categorías, proveedores (con icono de camión), localizaciones y bajo stock. Los administradores ven además usuarios y administradores.
+
+## Navegación Volver
+Los enlaces de **Detalles** agregan `returnTo=<URL>` y el botón **Volver** en el detalle usa ese valor o vuelve a `/productos` si no existe.
+
+## Filtros y ordenación
+`GET /productos` y `GET /inventario/bajo-stock` aceptan filtros por nombre (`qName`), comparadores `priceOp`/`price`, `stockOp`/`stock`, `minOp`/`min`, relaciones (`localizacionId`, `categoriaId`, `proveedorId`), ordenación (`sortBy`, `sortDir`) y el flag `low=1` en productos.
+
+## Títulos dinámicos
+El layout define `<title><%= title ? title + ' — ' : '' %>Inventario</title>` para que cada vista establezca su propio título.
+
 ## Política de comentarios ("supercomentado")
 - `src/app.js` y `src/config/db.js`: comentados línea a línea explicando qué hace cada instrucción y por qué.
 - Resto de archivos (`routes/`, `controllers/`, `validators/`, `views/`): comentarios por bloques cubriendo propósito, entradas/salidas, validaciones y manejo de errores.
@@ -186,15 +198,12 @@ Revisa inputs de formularios con express-validator (servidor) además de validac
 - El script de semillas trunca tablas, por lo que cualquier dato previo se pierde.
 
 ## Pruebas manuales
-1. Importar seeds: `mysql -u root -p inventario < db/seeds/20250901_semillas_realistas.sql` (o `db/seeds/20250903_semillas_realistas_delete.sql` si TRUNCATE falla).
-2. Login operador: `marta.jimenez@tienda.local` / `usuario123`.
-3. Visitar `/panel`: se muestran tarjetas de Productos, Categorías, Proveedores, Localizaciones y Bajo stock.
-4. Login admin: `laura.gonzalez@tienda.local` / `admin123`.
-5. `/panel` añade tarjetas de Usuarios y Admins.
-6. En móvil, abrir menú: saludo "Hola, Nombre (rol)" arriba del desplegable.
-7. Navegar entre secciones: el enlace activo se resalta y hay separadores.
-8. Comprobar títulos del navegador cambian según la vista.
-9. Regresión básica: `/panel`, `/login`, `/health`, `/resources` y `/db-health` responden 200.
+1. Panel: la tarjeta de **Proveedores** muestra icono y conteo correctos.
+2. Productos: filtrar por nombre parcial, precio ≤, stock ≥, localización, categoría y proveedor; ordenar por precio descendente. Los enlaces **Detalles** incluyen `returnTo` y **Volver** regresa al listado con filtros.
+3. Bajo stock: aplicar filtros (sin `low`), se ve la columna Localización. Enlace **Detalles** + **Volver** devuelve a la lista con filtros.
+4. Navbar: en móvil el saludo aparece arriba y no es clicable; en escritorio está a la derecha. Enlaces activos con separadores visibles.
+5. Títulos: el navegador muestra "Productos — Inventario", "Bajo stock — Inventario" y "Panel de inventario — Inventario" según la vista.
+6. Regresión básica: `/panel`, `/login`, `/health`, `/resources` y `/db-health` responden 200.
 
 ## Resumen de cambios
 - Semillas realistas con múltiples entidades y contraseñas bcrypt.
@@ -202,6 +211,7 @@ Revisa inputs de formularios con express-validator (servidor) además de validac
 - Interfaz de productos con columnas separadas de stock y stock mínimo.
 - Panel de inventario con contadores y navegación destacada.
 - Navbar responsive con saludo y títulos dinámicos.
+- Filtros avanzados en listados y navegación "Volver" con `returnTo`.
 
 ## Changelog
 ### 2025-08-26
@@ -219,3 +229,9 @@ Revisa inputs de formularios con express-validator (servidor) además de validac
 - Panel de inventario con contadores.
 - Navbar responsive con saludo, enlaces activos y títulos dinámicos.
 - Script alternativo `20250903_semillas_realistas_delete.sql` sin TRUNCATE.
+
+### 2025-09-20
+- Icono para Proveedores en panel.
+- Filtros y ordenación en listados de productos y bajo stock.
+- Ruta `/inventario/bajo-stock` con columna Localización.
+- Navegación "Volver" con parámetro `returnTo` y títulos dinámicos en todas las vistas.

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ const requireRole = require('./middlewares/requireRole'); // Middleware que limi
 const authRoutes = require('./routes/auth.routes');               // Conjunto de rutas de autenticación
 const panelRoutes = require('./routes/panel.routes');             // Conjunto de rutas del panel de inventario
 const productosRoutes = require('./routes/productos.routes');     // Conjunto de rutas CRUD de productos
+const bajoStockRoutes = require('./routes/bajo-stock.routes');    // Conjunto de rutas de productos con bajo stock
 const categoriasRoutes = require('./routes/categorias.routes');   // Conjunto de rutas CRUD de categorías
 const proveedoresRoutes = require('./routes/proveedores.routes'); // Conjunto de rutas CRUD de proveedores
 const localizacionesRoutes = require('./routes/localizaciones.routes'); // Conjunto de rutas CRUD de localizaciones
@@ -68,6 +69,7 @@ app.get('/db-health', async (req, res) => {       // Verifica conexión con la b
 app.use('/', authRoutes);                         // Monta rutas de login/logout
 app.use('/panel', requireAuth, panelRoutes);      // Panel de inventario con métricas
 app.use('/productos', requireAuth, productosRoutes);       // CRUD de productos (protección por login)
+app.use('/inventario/bajo-stock', requireAuth, bajoStockRoutes); // Listado de productos con bajo stock
 app.use('/categorias', requireAuth, categoriasRoutes);    // CRUD de categorías (protección por login)
 app.use('/proveedores', requireAuth, proveedoresRoutes);  // CRUD de proveedores (protección por login)
 app.use('/localizaciones', requireAuth, localizacionesRoutes); // CRUD de localizaciones (protección por login)

--- a/src/controllers/bajo-stock.controller.js
+++ b/src/controllers/bajo-stock.controller.js
@@ -1,0 +1,92 @@
+const pool = require('../config/db');
+const { validationResult } = require('express-validator');
+
+// Listado de productos con stock por debajo del mínimo
+exports.list = async (req, res) => {
+  const errors = validationResult(req); // Validación de query params
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() }); // Devuelve errores si la query es inválida
+  }
+
+  const page = parseInt(req.query.page) || 1; // Página actual
+  const limit = 10;                           // Elementos por página
+  const offset = (page - 1) * limit;          // Desplazamiento
+
+  const SORTABLE = {                          // Whitelist de campos ordenables
+    id: 'p.id',
+    nombre: 'p.nombre',
+    precio: 'p.precio',
+    stock: 'p.stock',
+    stock_minimo: 'p.stock_minimo'
+  };
+  const OP_MAP = { eq: '=', lte: '<=', gte: '>=' }; // Mapa de operadores permitidos
+
+  const sortBy = SORTABLE[req.query.sortBy] || 'p.id';
+  const sortDir = (req.query.sortDir || 'asc').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+
+  const joins = [];                             // Joins condicionales
+  const where = ['p.stock < p.stock_minimo'];    // Filtro fijo de bajo stock
+  const params = [];                            // Valores parametrizados
+
+  if (req.query.qName) {                        // Búsqueda por nombre
+    where.push('LOWER(p.nombre) LIKE ?');
+    params.push(`%${req.query.qName.toLowerCase()}%`);
+  }
+  if (req.query.price && req.query.priceOp) {   // Filtro por precio
+    where.push(`p.precio ${OP_MAP[req.query.priceOp]} ?`);
+    params.push(req.query.price);
+  }
+  if (req.query.stock && req.query.stockOp) {   // Filtro por stock
+    where.push(`p.stock ${OP_MAP[req.query.stockOp]} ?`);
+    params.push(req.query.stock);
+  }
+  if (req.query.min && req.query.minOp) {       // Filtro por stock mínimo
+    where.push(`p.stock_minimo ${OP_MAP[req.query.minOp]} ?`);
+    params.push(req.query.min);
+  }
+  if (req.query.localizacionId) {               // Filtro por localización
+    where.push('p.localizacion_id = ?');
+    params.push(req.query.localizacionId);
+  }
+  if (req.query.categoriaId) {                  // Filtro por categoría
+    joins.push('JOIN producto_categoria pc ON pc.producto_id = p.id');
+    where.push('pc.categoria_id = ?');
+    params.push(req.query.categoriaId);
+  }
+  if (req.query.proveedorId) {                  // Filtro por proveedor
+    joins.push('JOIN producto_proveedor pp ON pp.producto_id = p.id');
+    where.push('pp.proveedor_id = ?');
+    params.push(req.query.proveedorId);
+  }
+
+  const whereSql = 'WHERE ' + where.join(' AND ');
+  const baseSql = `FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id ${joins.join(' ')}`;
+
+  const [rows] = await pool.query(
+    `SELECT DISTINCT p.*, l.nombre AS localizacion ${baseSql} ${whereSql} ORDER BY ${sortBy} ${sortDir} LIMIT ? OFFSET ?`,
+    [...params, limit, offset]
+  );
+
+  const [countRows] = await pool.query(
+    `SELECT COUNT(DISTINCT p.id) AS total ${baseSql} ${whereSql}`,
+    params
+  );
+
+  const totalPages = Math.ceil(countRows[0].total / limit);
+
+  const [localizaciones] = await pool.query('SELECT id, nombre FROM localizaciones');
+  const [categorias] = await pool.query('SELECT id, nombre FROM categorias');
+  const [proveedores] = await pool.query('SELECT id, nombre FROM proveedores');
+
+  res.render('pages/bajo-stock', {
+    title: 'Bajo stock',
+    productos: rows,
+    page,
+    totalPages,
+    localizaciones,
+    categorias,
+    proveedores,
+    filters: req.query,
+    request: req
+  });
+};

--- a/src/controllers/panel.controller.js
+++ b/src/controllers/panel.controller.js
@@ -4,6 +4,15 @@ const pool = require('../config/db');
 exports.index = async (req, res) => {
   const isAdmin = req.session.user && req.session.user.rol === 'admin'; // Verifica si el usuario es admin
   const counts = {};                                                   // Objeto que acumula los totales
+  const icons = {                                                     // Iconos Boxicons para cada tarjeta
+    productos: 'bx bx-box',
+    categorias: 'bx bx-list-ul',
+    proveedores: 'bxs-truck',
+    localizaciones: 'bx bx-map',
+    bajoStock: 'bx bx-error',
+    usuarios: 'bx bx-user',
+    admins: 'bx bx-user-check'
+  };
 
   const [prod] = await pool.query('SELECT COUNT(*) AS n FROM productos');
   const [cat] = await pool.query('SELECT COUNT(*) AS n FROM categorias');
@@ -24,5 +33,5 @@ exports.index = async (req, res) => {
     counts.admins = adm[0].n;
   }
 
-  res.render('pages/panel', { title: 'Panel de inventario', counts, isAdmin });
+  res.render('pages/panel', { title: 'Panel de inventario', counts, icons, isAdmin });
 };

--- a/src/controllers/productos.controller.js
+++ b/src/controllers/productos.controller.js
@@ -1,21 +1,97 @@
 const pool = require('../config/db');
 const { validationResult } = require('express-validator');
 
-// Listar productos con paginación simple
+// Listar productos con filtros, ordenación y paginación
 exports.list = async (req, res) => {
-  const page = parseInt(req.query.page) || 1; // página actual
-  const limit = 10;                           // elementos por página
-  const offset = (page - 1) * limit;          // desplazamiento
-  const [rows] = await pool.query(`SELECT p.*, l.nombre AS localizacion FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id LIMIT ? OFFSET ?`, [limit, offset]);
-  const [countRows] = await pool.query('SELECT COUNT(*) AS total FROM productos');
-  const totalPages = Math.ceil(countRows[0].total / limit);
-  res.render('pages/productos/list', { title: 'Productos', productos: rows, bajoStock: false, page, totalPages });
-};
+  const errors = validationResult(req); // Validación de query params
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() }); // Devuelve errores si la query es inválida
+  }
 
-// Vista de productos bajo stock utilizando la VIEW creada en SQL
-exports.bajoStock = async (req, res) => {
-  const [rows] = await pool.query('SELECT * FROM productos_bajo_stock');
-  res.render('pages/productos/list', { title: 'Productos bajo stock', productos: rows, bajoStock: true, page: 1, totalPages: 1 });
+  const page = parseInt(req.query.page) || 1; // Página actual
+  const limit = 10;                           // Elementos por página
+  const offset = (page - 1) * limit;          // Desplazamiento
+
+  const SORTABLE = {                          // Whitelist de campos ordenables
+    id: 'p.id',
+    nombre: 'p.nombre',
+    precio: 'p.precio',
+    stock: 'p.stock',
+    stock_minimo: 'p.stock_minimo'
+  };
+  const OP_MAP = { eq: '=', lte: '<=', gte: '>=' }; // Mapa de operadores permitidos
+
+  const sortBy = SORTABLE[req.query.sortBy] || 'p.id';
+  const sortDir = (req.query.sortDir || 'asc').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+
+  const joins = [];                             // Joins condicionales
+  const where = [];                             // Filtros dinámicos
+  const params = [];                            // Valores parametrizados
+
+  if (req.query.qName) {                        // Búsqueda por nombre
+    where.push('LOWER(p.nombre) LIKE ?');
+    params.push(`%${req.query.qName.toLowerCase()}%`);
+  }
+  if (req.query.price && req.query.priceOp) {   // Filtro por precio
+    where.push(`p.precio ${OP_MAP[req.query.priceOp]} ?`);
+    params.push(req.query.price);
+  }
+  if (req.query.stock && req.query.stockOp) {   // Filtro por stock
+    where.push(`p.stock ${OP_MAP[req.query.stockOp]} ?`);
+    params.push(req.query.stock);
+  }
+  if (req.query.min && req.query.minOp) {       // Filtro por stock mínimo
+    where.push(`p.stock_minimo ${OP_MAP[req.query.minOp]} ?`);
+    params.push(req.query.min);
+  }
+  if (req.query.localizacionId) {               // Filtro por localización
+    where.push('p.localizacion_id = ?');
+    params.push(req.query.localizacionId);
+  }
+  if (req.query.categoriaId) {                  // Filtro por categoría
+    joins.push('JOIN producto_categoria pc ON pc.producto_id = p.id');
+    where.push('pc.categoria_id = ?');
+    params.push(req.query.categoriaId);
+  }
+  if (req.query.proveedorId) {                  // Filtro por proveedor
+    joins.push('JOIN producto_proveedor pp ON pp.producto_id = p.id');
+    where.push('pp.proveedor_id = ?');
+    params.push(req.query.proveedorId);
+  }
+  if (req.query.low === '1') {                  // Solo bajo stock
+    where.push('p.stock < p.stock_minimo');
+  }
+
+  const whereSql = where.length ? 'WHERE ' + where.join(' AND ') : '';
+  const baseSql = `FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id ${joins.join(' ')}`;
+
+  const [rows] = await pool.query(
+    `SELECT DISTINCT p.*, l.nombre AS localizacion ${baseSql} ${whereSql} ORDER BY ${sortBy} ${sortDir} LIMIT ? OFFSET ?`,
+    [...params, limit, offset]
+  );
+
+  const [countRows] = await pool.query(
+    `SELECT COUNT(DISTINCT p.id) AS total ${baseSql} ${whereSql}`,
+    params
+  );
+
+  const totalPages = Math.ceil(countRows[0].total / limit);
+
+  const [localizaciones] = await pool.query('SELECT id, nombre FROM localizaciones');
+  const [categorias] = await pool.query('SELECT id, nombre FROM categorias');
+  const [proveedores] = await pool.query('SELECT id, nombre FROM proveedores');
+
+  res.render('pages/productos/list', {
+    title: 'Productos',
+    productos: rows,
+    page,
+    totalPages,
+    localizaciones,
+    categorias,
+    proveedores,
+    filters: req.query,
+    request: req
+  });
 };
 
 // Mostrar formulario de creación/edición
@@ -98,12 +174,21 @@ exports.remove = async (req, res) => {
 // Detalle de producto
 exports.detail = async (req, res) => {
   const id = req.params.id;
-  const [rows] = await pool.query(`SELECT p.*, l.nombre AS localizacion FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id WHERE p.id = ?`, [id]);
+  const [rows] = await pool.query(
+    `SELECT p.*, l.nombre AS localizacion FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id WHERE p.id = ?`,
+    [id]
+  );
   if (!rows.length) return res.redirect('/productos');
   const producto = rows[0];
-  const [cats] = await pool.query(`SELECT c.* FROM categorias c JOIN producto_categoria pc ON c.id = pc.categoria_id WHERE pc.producto_id = ?`, [id]);
-  const [provs] = await pool.query(`SELECT pr.* FROM proveedores pr JOIN producto_proveedor pp ON pr.id = pp.proveedor_id WHERE pp.producto_id = ?`, [id]);
+  const [cats] = await pool.query(
+    `SELECT c.* FROM categorias c JOIN producto_categoria pc ON c.id = pc.categoria_id WHERE pc.producto_id = ?`,
+    [id]
+  );
+  const [provs] = await pool.query(
+    `SELECT pr.* FROM proveedores pr JOIN producto_proveedor pp ON pr.id = pp.proveedor_id WHERE pp.producto_id = ?`,
+    [id]
+  );
   producto.categorias = cats;
   producto.proveedores = provs;
-  res.render('pages/productos/detail', { title: 'Detalle de producto', producto });
+  res.render('pages/productos/detail', { title: 'Detalle de producto', producto, returnTo: req.query.returnTo });
 };

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -10,6 +10,7 @@ body { padding-top: 60px; }
 .nav-link.active {
   font-weight: 500;
   border-bottom: 2px solid #fff;
+  border-radius: .25rem;
 }
 
 .nav-separated .nav-link {

--- a/src/routes/bajo-stock.routes.js
+++ b/src/routes/bajo-stock.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/bajo-stock.controller');
+const { productListValidator } = require('../validators/productos.validators');
+
+router.get('/', productListValidator, controller.list); // Listado bajo stock
+
+module.exports = router;

--- a/src/routes/productos.routes.js
+++ b/src/routes/productos.routes.js
@@ -1,10 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/productos.controller');
-const { productValidator } = require('../validators/productos.validators');
+const { productValidator, productListValidator } = require('../validators/productos.validators');
 
-router.get('/', controller.list);                      // Listado
-router.get('/bajo-stock', controller.bajoStock);       // Productos con stock bajo
+router.get('/', productListValidator, controller.list); // Listado con filtros
 router.get('/nuevo', controller.form);                 // Form crear
 router.post('/nuevo', productValidator, controller.create); // Guardar nuevo
 router.get('/:id/editar', controller.form);            // Form editar

--- a/src/validators/productos.validators.js
+++ b/src/validators/productos.validators.js
@@ -1,4 +1,4 @@
-const { body } = require('express-validator');
+const { body, query } = require('express-validator');
 
 // Validaciones para crear/editar productos
 exports.productValidator = [
@@ -7,4 +7,21 @@ exports.productValidator = [
   body('stock').isInt({ min: 0 }).withMessage('Stock inválido'),
   body('stock_minimo').isInt({ min: 0 }).withMessage('Stock mínimo inválido'),
   body('localizacion_id').isInt().withMessage('Seleccione una localización válida')
+];
+
+// Validaciones para filtros y ordenación de listados
+exports.productListValidator = [
+  query('sortBy').optional().isIn(['id', 'nombre', 'precio', 'stock', 'stock_minimo']),
+  query('sortDir').optional().isIn(['asc', 'desc']),
+  query('qName').optional().isString().trim().escape(),
+  query('priceOp').optional().isIn(['eq', 'lte', 'gte']),
+  query('price').optional().isFloat(),
+  query('stockOp').optional().isIn(['eq', 'lte', 'gte']),
+  query('stock').optional().isInt(),
+  query('minOp').optional().isIn(['eq', 'lte', 'gte']),
+  query('min').optional().isInt(),
+  query('localizacionId').optional().isInt({ min: 1 }),
+  query('categoriaId').optional().isInt({ min: 1 }),
+  query('proveedorId').optional().isInt({ min: 1 }),
+  query('low').optional().isInt({ min: 1, max: 1 })
 ];

--- a/src/views/pages/bajo-stock.ejs
+++ b/src/views/pages/bajo-stock.ejs
@@ -1,5 +1,4 @@
-<h1>Productos</h1>
-<a href="/productos/nuevo" class="btn btn-success mb-3">Nuevo</a>
+<h1>Bajo stock</h1>
 <form method="get" class="row g-2 mb-3">
   <div class="col-md-3">
     <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= filters.qName || '' %>">
@@ -61,12 +60,6 @@
       <% }) %>
     </select>
   </div>
-  <div class="col-md-3 d-flex align-items-center">
-    <div class="form-check">
-      <input class="form-check-input" type="checkbox" name="low" value="1" id="lowChk" <%= filters.low === '1' ? 'checked' : '' %>>
-      <label class="form-check-label" for="lowChk">Bajo stock</label>
-    </div>
-  </div>
   <div class="col-md-3">
     <select name="sortBy" class="form-select">
       <option value="id" <%= (filters.sortBy || 'id')==='id' ? 'selected' : '' %>>Ordenar por ID</option>
@@ -100,17 +93,15 @@
   </thead>
   <tbody>
     <% productos.forEach(p => { %>
-      <tr class="<%= p.stock < p.stock_minimo ? 'table-warning' : '' %>">
+      <tr class="table-warning">
         <td><%= p.id %></td>
         <td><%= p.nombre %></td>
         <td><%= p.precio %></td>
-        <td><%= p.stock %> <% if (p.stock < p.stock_minimo) { %><span class="badge bg-danger">Bajo stock</span><% } %></td>
+        <td><%= p.stock %></td>
         <td><%= p.stock_minimo %></td>
         <td><%= p.localizacion %></td>
         <td>
           <a href="/productos/<%= p.id %>?returnTo=<%= encodeURIComponent(request.originalUrl) %>" class="btn btn-sm btn-primary"><i class='bx bx-show'></i></a>
-          <a href="/productos/<%= p.id %>/editar" class="btn btn-sm btn-warning"><i class='bx bx-edit'></i></a>
-          <a href="/productos/<%= p.id %>/eliminar" class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar?')"><i class='bx bx-trash'></i></a>
         </td>
       </tr>
     <% }) %>

--- a/src/views/pages/panel.ejs
+++ b/src/views/pages/panel.ejs
@@ -3,7 +3,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='bx bx-box fs-1'></i>
+        <i class='<%= icons.productos %> fs-1'></i>
         <p class="display-6"><%= counts.productos %></p>
         <p class="text-muted mb-0">Productos</p>
       </div>
@@ -12,7 +12,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='bx bx-list-ul fs-1'></i>
+        <i class='<%= icons.categorias %> fs-1'></i>
         <p class="display-6"><%= counts.categorias %></p>
         <p class="text-muted mb-0">Categorías</p>
       </div>
@@ -21,7 +21,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='bx bx-truck fs-1'></i>
+        <i class='<%= icons.proveedores %> fs-1'></i>
         <p class="display-6"><%= counts.proveedores %></p>
         <p class="text-muted mb-0">Proveedores</p>
       </div>
@@ -30,7 +30,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='bx bx-map fs-1'></i>
+        <i class='<%= icons.localizaciones %> fs-1'></i>
         <p class="display-6"><%= counts.localizaciones %></p>
         <p class="text-muted mb-0">Localizaciones</p>
       </div>
@@ -39,7 +39,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='bx bx-error fs-1'></i>
+        <i class='<%= icons.bajoStock %> fs-1'></i>
         <p class="display-6"><%= counts.bajoStock %></p>
         <p class="text-muted mb-0">Bajo stock</p>
       </div>
@@ -49,7 +49,7 @@
     <div class="col-6 col-md-4 col-lg-2">
       <div class="card text-center h-100">
         <div class="card-body">
-          <i class='bx bx-user fs-1'></i>
+          <i class='<%= icons.usuarios %> fs-1'></i>
           <p class="display-6"><%= counts.usuarios %></p>
           <p class="text-muted mb-0">Usuarios</p>
         </div>
@@ -58,7 +58,7 @@
     <div class="col-6 col-md-4 col-lg-2">
       <div class="card text-center h-100">
         <div class="card-body">
-          <i class='bx bx-user-check fs-1'></i>
+          <i class='<%= icons.admins %> fs-1'></i>
           <p class="display-6"><%= counts.admins %></p>
           <p class="text-muted mb-0">Admins</p>
         </div>

--- a/src/views/pages/productos/detail.ejs
+++ b/src/views/pages/productos/detail.ejs
@@ -5,4 +5,4 @@
 <p><strong>Localización:</strong> <%= producto.localizacion %></p>
 <p><strong>Categorías:</strong> <%= producto.categorias.map(c=>c.nombre).join(', ') %></p>
 <p><strong>Proveedores:</strong> <%= producto.proveedores.map(p=>p.nombre).join(', ') %></p>
-<a href="/productos" class="btn btn-secondary">Volver</a>
+<a href="<%= returnTo || '/productos' %>" class="btn btn-secondary">Volver</a>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -10,11 +10,11 @@
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
           <% if (isAuthenticated) { %>
             <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/panel') ? 'active' : '' %>" href="/panel">Panel</a></li>
-            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/productos') && !currentPath.includes('/bajo-stock') ? 'active' : '' %>" href="/productos">Productos</a></li>
+            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/productos') ? 'active' : '' %>" href="/productos">Productos</a></li>
             <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/categorias') ? 'active' : '' %>" href="/categorias">Categorías</a></li>
             <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/proveedores') ? 'active' : '' %>" href="/proveedores">Proveedores</a></li>
             <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/localizaciones') ? 'active' : '' %>" href="/localizaciones">Localizaciones</a></li>
-            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/productos/bajo-stock') ? 'active' : '' %>" href="/productos/bajo-stock">Bajo stock</a></li>
+            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/inventario/bajo-stock') ? 'active' : '' %>" href="/inventario/bajo-stock">Bajo stock</a></li>
             <% if (userRole === 'admin') { %>
               <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/usuarios') ? 'active' : '' %>" href="/usuarios">Usuarios</a></li>
             <% } %>


### PR DESCRIPTION
## Summary
- add provider icon in dashboard
- support filter/sort for product and low-stock lists with return links
- implement dedicated low-stock route and view with location column

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b799166fc0832a88c8042fd5b38613