### PR TITLE
Improve filter validation and search UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ En XAMPP/MAMP el usuario `root` suele ir sin contraseña → deja `DB_PASSWORD` 
 - Panel de inventario con contadores.
 - Navbar responsive con saludo y enlaces activos.
 - Títulos dinámicos por vista.
+- Listados con filtros opcionales y panel de búsqueda plegable.
+- Navegación de detalle con parámetro `returnTo` para conservar filtros.
 
 ## Datos de ejemplo
 Incluye un script con usuarios, categorías, proveedores, localizaciones y más de veinte productos.
@@ -198,9 +200,9 @@ Revisa inputs de formularios con express-validator (servidor) además de validac
 - El script de semillas trunca tablas, por lo que cualquier dato previo se pierde.
 
 ## Pruebas manuales
-1. Panel: la tarjeta de **Proveedores** muestra icono y conteo correctos.
-2. Productos: filtrar por nombre parcial, precio ≤, stock ≥, localización, categoría y proveedor; ordenar por precio descendente. Los enlaces **Detalles** incluyen `returnTo` y **Volver** regresa al listado con filtros.
-3. Bajo stock: aplicar filtros (sin `low`), se ve la columna Localización. Enlace **Detalles** + **Volver** devuelve a la lista con filtros.
+1. Panel: la tarjeta de **Proveedores** muestra icono válido y conteo correcto.
+2. Productos: pulsar **Buscar** despliega el panel, enviar filtros vacíos no arroja errores. Probar combinaciones como nombre parcial + precio ≤ + proveedor. Ordenar por precio descendente y luego por nombre ascendente. Enlace **Detalles** incluye `returnTo` y el botón **Volver** respeta los filtros.
+3. Bajo stock: botón **Buscar** con los mismos filtros (sin `low`). Ver columna Localización y filtrar por localización, categoría y proveedor. Enlace **Detalles** + **Volver** retorna a la lista con filtros.
 4. Navbar: en móvil el saludo aparece arriba y no es clicable; en escritorio está a la derecha. Enlaces activos con separadores visibles.
 5. Títulos: el navegador muestra "Productos — Inventario", "Bajo stock — Inventario" y "Panel de inventario — Inventario" según la vista.
 6. Regresión básica: `/panel`, `/login`, `/health`, `/resources` y `/db-health` responden 200.
@@ -235,3 +237,8 @@ Revisa inputs de formularios con express-validator (servidor) además de validac
 - Filtros y ordenación en listados de productos y bajo stock.
 - Ruta `/inventario/bajo-stock` con columna Localización.
 - Navegación "Volver" con parámetro `returnTo` y títulos dinámicos en todas las vistas.
+
+### 2025-09-30
+- Panel de búsqueda plegable con filtros opcionales y validación amigable en Productos y Bajo stock.
+- Icono de Proveedores corregido y estilos unificados de iconos.
+- `returnTo` preserva filtros al navegar al detalle.

--- a/src/app.js
+++ b/src/app.js
@@ -41,13 +41,14 @@ app.use(session({                               // Inicializa la gestión de ses
   cookie: { httpOnly: true, sameSite: 'lax' }     // Protege contra XSS y CSRF básicas
 }));
 
-app.use((req, res, next) => {                     // Middleware que expone datos de sesión y ruta actual
-  res.locals.currentPath = req.path;              // Ruta actual para resaltar enlaces activos
-  res.locals.isAuthenticated = !!req.session.user; // Booleano con estado de autenticación
-  res.locals.userName = req.session.user ? req.session.user.nombre : null; // Nombre del usuario
-  res.locals.userRole = req.session.user ? req.session.user.rol : null;    // Rol del usuario logueado
-  next();                                         // Continúa con el siguiente middleware
-});
+  app.use((req, res, next) => {                     // Middleware que expone datos de sesión y ruta actual
+    res.locals.currentPath = req.path;              // Ruta actual para resaltar enlaces activos
+    res.locals.isAuthenticated = !!req.session.user; // Booleano con estado de autenticación
+    res.locals.userName = req.session.user ? req.session.user.nombre : null; // Nombre del usuario
+    res.locals.userRole = req.session.user ? req.session.user.rol : null;    // Rol del usuario logueado
+    res.locals.request = req;                      // Objeto de la petición disponible en las vistas
+    next();                                         // Continúa con el siguiente middleware
+  });
 
 app.get('/', requireAuth, (req, res) => {         // Página principal protegida por login
   res.redirect('/panel');                        // Redirige al panel de inventario

--- a/src/controllers/bajo-stock.controller.js
+++ b/src/controllers/bajo-stock.controller.js
@@ -1,74 +1,73 @@
 const pool = require('../config/db');
-const { validationResult } = require('express-validator');
+const { validationResult, matchedData } = require('express-validator');
 
 // Listado de productos con stock por debajo del mínimo
 exports.list = async (req, res) => {
   const errors = validationResult(req); // Validación de query params
-  if (!errors.isEmpty()) {
-    return res.status(400).json({ errors: errors.array() }); // Devuelve errores si la query es inválida
-  }
+  const data = matchedData(req, { locations: ['query'] }); // Datos saneados
 
   const page = parseInt(req.query.page) || 1; // Página actual
   const limit = 10;                           // Elementos por página
   const offset = (page - 1) * limit;          // Desplazamiento
 
-  const SORTABLE = {                          // Whitelist de campos ordenables
+  const SORTABLE = {                          // Map de columnas ordenables
     id: 'p.id',
     nombre: 'p.nombre',
     precio: 'p.precio',
     stock: 'p.stock',
     stock_minimo: 'p.stock_minimo'
   };
-  const OP_MAP = { eq: '=', lte: '<=', gte: '>=' }; // Mapa de operadores permitidos
+  const OP_MAP = { eq: '=', lte: '<=', gte: '>=' }; // Operadores permitidos
 
-  const sortBy = SORTABLE[req.query.sortBy] || 'p.id';
-  const sortDir = (req.query.sortDir || 'asc').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+  const sortCol = SORTABLE[data.sortBy] || 'p.id';
+  const sortDirSql = (data.sortDir || 'asc').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
 
   const joins = [];                             // Joins condicionales
   const where = ['p.stock < p.stock_minimo'];    // Filtro fijo de bajo stock
   const params = [];                            // Valores parametrizados
 
-  if (req.query.qName) {                        // Búsqueda por nombre
-    where.push('LOWER(p.nombre) LIKE ?');
-    params.push(`%${req.query.qName.toLowerCase()}%`);
+  if (data.qName) {
+    where.push('p.nombre LIKE ?');
+    params.push(`%${data.qName}%`);
   }
-  if (req.query.price && req.query.priceOp) {   // Filtro por precio
-    where.push(`p.precio ${OP_MAP[req.query.priceOp]} ?`);
-    params.push(req.query.price);
+  if (data.price != null && data.priceOp && OP_MAP[data.priceOp]) {
+    where.push(`p.precio ${OP_MAP[data.priceOp]} ?`);
+    params.push(data.price);
   }
-  if (req.query.stock && req.query.stockOp) {   // Filtro por stock
-    where.push(`p.stock ${OP_MAP[req.query.stockOp]} ?`);
-    params.push(req.query.stock);
+  if (data.stock != null && data.stockOp && OP_MAP[data.stockOp]) {
+    where.push(`p.stock ${OP_MAP[data.stockOp]} ?`);
+    params.push(data.stock);
   }
-  if (req.query.min && req.query.minOp) {       // Filtro por stock mínimo
-    where.push(`p.stock_minimo ${OP_MAP[req.query.minOp]} ?`);
-    params.push(req.query.min);
+  if (data.min != null && data.minOp && OP_MAP[data.minOp]) {
+    where.push(`p.stock_minimo ${OP_MAP[data.minOp]} ?`);
+    params.push(data.min);
   }
-  if (req.query.localizacionId) {               // Filtro por localización
+  if (data.localizacionId) {
     where.push('p.localizacion_id = ?');
-    params.push(req.query.localizacionId);
+    params.push(data.localizacionId);
   }
-  if (req.query.categoriaId) {                  // Filtro por categoría
+  if (data.categoriaId) {
     joins.push('JOIN producto_categoria pc ON pc.producto_id = p.id');
     where.push('pc.categoria_id = ?');
-    params.push(req.query.categoriaId);
+    params.push(data.categoriaId);
   }
-  if (req.query.proveedorId) {                  // Filtro por proveedor
+  if (data.proveedorId) {
     joins.push('JOIN producto_proveedor pp ON pp.producto_id = p.id');
     where.push('pp.proveedor_id = ?');
-    params.push(req.query.proveedorId);
+    params.push(data.proveedorId);
   }
 
   const whereSql = 'WHERE ' + where.join(' AND ');
-  const baseSql = `FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id ${joins.join(' ')}`;
+  const joinSql = joins.join(' ');
+  const baseSql = `FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id ${joinSql} ${whereSql}`;
 
   const [rows] = await pool.query(
-    `SELECT DISTINCT p.*, l.nombre AS localizacion ${baseSql} ${whereSql} ORDER BY ${sortBy} ${sortDir} LIMIT ? OFFSET ?`,
+    `SELECT DISTINCT p.*, l.nombre AS localizacion ${baseSql} ORDER BY ${sortCol} ${sortDirSql} LIMIT ? OFFSET ?`,
     [...params, limit, offset]
   );
 
   const [countRows] = await pool.query(
-    `SELECT COUNT(DISTINCT p.id) AS total ${baseSql} ${whereSql}`,
+    `SELECT COUNT(DISTINCT p.id) AS total ${baseSql}`,
     params
   );
 
@@ -86,7 +85,7 @@ exports.list = async (req, res) => {
     localizaciones,
     categorias,
     proveedores,
-    filters: req.query,
-    request: req
+    query: req.query,
+    errors: errors.array()
   });
 };

--- a/src/controllers/panel.controller.js
+++ b/src/controllers/panel.controller.js
@@ -4,15 +4,15 @@ const pool = require('../config/db');
 exports.index = async (req, res) => {
   const isAdmin = req.session.user && req.session.user.rol === 'admin'; // Verifica si el usuario es admin
   const counts = {};                                                   // Objeto que acumula los totales
-  const icons = {                                                     // Iconos Boxicons para cada tarjeta
-    productos: 'bx bx-box',
-    categorias: 'bx bx-list-ul',
-    proveedores: 'bxs-truck',
-    localizaciones: 'bx bx-map',
-    bajoStock: 'bx bx-error',
-    usuarios: 'bx bx-user',
-    admins: 'bx bx-user-check'
-  };
+    const icons = {                                                     // Iconos Boxicons para cada tarjeta
+      productos: 'bx bx-box',
+      categorias: 'bx bx-list-ul',
+      proveedores: 'bx bxs-truck',
+      localizaciones: 'bx bx-map',
+      bajoStock: 'bx bx-error',
+      usuarios: 'bx bx-user',
+      admins: 'bx bx-user-check'
+    };
 
   const [prod] = await pool.query('SELECT COUNT(*) AS n FROM productos');
   const [cat] = await pool.query('SELECT COUNT(*) AS n FROM categorias');

--- a/src/controllers/productos.controller.js
+++ b/src/controllers/productos.controller.js
@@ -1,77 +1,76 @@
 const pool = require('../config/db');
-const { validationResult } = require('express-validator');
+const { validationResult, matchedData } = require('express-validator');
 
 // Listar productos con filtros, ordenación y paginación
 exports.list = async (req, res) => {
   const errors = validationResult(req); // Validación de query params
-  if (!errors.isEmpty()) {
-    return res.status(400).json({ errors: errors.array() }); // Devuelve errores si la query es inválida
-  }
+  const data = matchedData(req, { locations: ['query'] }); // Datos saneados
 
   const page = parseInt(req.query.page) || 1; // Página actual
   const limit = 10;                           // Elementos por página
   const offset = (page - 1) * limit;          // Desplazamiento
 
-  const SORTABLE = {                          // Whitelist de campos ordenables
+  const SORTABLE = {                          // Map de columnas ordenables
     id: 'p.id',
     nombre: 'p.nombre',
     precio: 'p.precio',
     stock: 'p.stock',
     stock_minimo: 'p.stock_minimo'
   };
-  const OP_MAP = { eq: '=', lte: '<=', gte: '>=' }; // Mapa de operadores permitidos
+  const OP_MAP = { eq: '=', lte: '<=', gte: '>=' }; // Operadores permitidos
 
-  const sortBy = SORTABLE[req.query.sortBy] || 'p.id';
-  const sortDir = (req.query.sortDir || 'asc').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+  const sortCol = SORTABLE[data.sortBy] || 'p.id';
+  const sortDirSql = (data.sortDir || 'asc').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
 
-  const joins = [];                             // Joins condicionales
-  const where = [];                             // Filtros dinámicos
-  const params = [];                            // Valores parametrizados
+  const joins = [];   // Joins condicionales
+  const clauses = []; // Condiciones WHERE
+  const params = [];  // Valores parametrizados
 
-  if (req.query.qName) {                        // Búsqueda por nombre
-    where.push('LOWER(p.nombre) LIKE ?');
-    params.push(`%${req.query.qName.toLowerCase()}%`);
+  if (data.qName) {
+    clauses.push('p.nombre LIKE ?');
+    params.push(`%${data.qName}%`);
   }
-  if (req.query.price && req.query.priceOp) {   // Filtro por precio
-    where.push(`p.precio ${OP_MAP[req.query.priceOp]} ?`);
-    params.push(req.query.price);
+  if (data.price != null && data.priceOp && OP_MAP[data.priceOp]) {
+    clauses.push(`p.precio ${OP_MAP[data.priceOp]} ?`);
+    params.push(data.price);
   }
-  if (req.query.stock && req.query.stockOp) {   // Filtro por stock
-    where.push(`p.stock ${OP_MAP[req.query.stockOp]} ?`);
-    params.push(req.query.stock);
+  if (data.stock != null && data.stockOp && OP_MAP[data.stockOp]) {
+    clauses.push(`p.stock ${OP_MAP[data.stockOp]} ?`);
+    params.push(data.stock);
   }
-  if (req.query.min && req.query.minOp) {       // Filtro por stock mínimo
-    where.push(`p.stock_minimo ${OP_MAP[req.query.minOp]} ?`);
-    params.push(req.query.min);
+  if (data.min != null && data.minOp && OP_MAP[data.minOp]) {
+    clauses.push(`p.stock_minimo ${OP_MAP[data.minOp]} ?`);
+    params.push(data.min);
   }
-  if (req.query.localizacionId) {               // Filtro por localización
-    where.push('p.localizacion_id = ?');
-    params.push(req.query.localizacionId);
+  if (data.localizacionId) {
+    clauses.push('p.localizacion_id = ?');
+    params.push(data.localizacionId);
   }
-  if (req.query.categoriaId) {                  // Filtro por categoría
+  if (data.categoriaId) {
     joins.push('JOIN producto_categoria pc ON pc.producto_id = p.id');
-    where.push('pc.categoria_id = ?');
-    params.push(req.query.categoriaId);
+    clauses.push('pc.categoria_id = ?');
+    params.push(data.categoriaId);
   }
-  if (req.query.proveedorId) {                  // Filtro por proveedor
+  if (data.proveedorId) {
     joins.push('JOIN producto_proveedor pp ON pp.producto_id = p.id');
-    where.push('pp.proveedor_id = ?');
-    params.push(req.query.proveedorId);
+    clauses.push('pp.proveedor_id = ?');
+    params.push(data.proveedorId);
   }
-  if (req.query.low === '1') {                  // Solo bajo stock
-    where.push('p.stock < p.stock_minimo');
+  if (data.low === '1') {
+    clauses.push('p.stock < p.stock_minimo');
   }
 
-  const whereSql = where.length ? 'WHERE ' + where.join(' AND ') : '';
-  const baseSql = `FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id ${joins.join(' ')}`;
+  const whereSql = clauses.length ? 'WHERE ' + clauses.join(' AND ') : '';
+  const joinSql = joins.join(' ');
+  const baseSql = `FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id ${joinSql} ${whereSql}`;
 
   const [rows] = await pool.query(
-    `SELECT DISTINCT p.*, l.nombre AS localizacion ${baseSql} ${whereSql} ORDER BY ${sortBy} ${sortDir} LIMIT ? OFFSET ?`,
+    `SELECT DISTINCT p.*, l.nombre AS localizacion ${baseSql} ORDER BY ${sortCol} ${sortDirSql} LIMIT ? OFFSET ?`,
     [...params, limit, offset]
   );
 
   const [countRows] = await pool.query(
-    `SELECT COUNT(DISTINCT p.id) AS total ${baseSql} ${whereSql}`,
+    `SELECT COUNT(DISTINCT p.id) AS total ${baseSql}`,
     params
   );
 
@@ -89,8 +88,8 @@ exports.list = async (req, res) => {
     localizaciones,
     categorias,
     proveedores,
-    filters: req.query,
-    request: req
+    query: req.query,
+    errors: errors.array()
   });
 };
 

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -13,18 +13,10 @@ body { padding-top: 60px; }
   border-radius: .25rem;
 }
 
-.nav-separated .nav-link {
-  position: relative;
-  margin: 0 .5rem;
+.nav-separated .nav-link + .nav-link {
+  border-left: 1px solid rgba(0,0,0,.1);
 }
 
-.nav-separated .nav-link + .nav-link::before {
-  content: '';
-  position: absolute;
-  left: -0.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 1px;
-  height: 1.25rem;
-  background-color: rgba(255,255,255,0.2);
+.tile-icon {
+  font-size: 1.75rem;
 }

--- a/src/routes/bajo-stock.routes.js
+++ b/src/routes/bajo-stock.routes.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/bajo-stock.controller');
-const { productListValidator } = require('../validators/productos.validators');
+const { listFilters } = require('../validators/bajo-stock.validators');
 
-router.get('/', productListValidator, controller.list); // Listado bajo stock
+router.get('/', listFilters, controller.list); // Listado bajo stock
 
 module.exports = router;

--- a/src/routes/productos.routes.js
+++ b/src/routes/productos.routes.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/productos.controller');
-const { productValidator, productListValidator } = require('../validators/productos.validators');
+const { productValidator, listFilters } = require('../validators/productos.validators');
 
-router.get('/', productListValidator, controller.list); // Listado con filtros
+router.get('/', listFilters, controller.list); // Listado con filtros
 router.get('/nuevo', controller.form);                 // Form crear
 router.post('/nuevo', productValidator, controller.create); // Guardar nuevo
 router.get('/:id/editar', controller.form);            // Form editar

--- a/src/validators/bajo-stock.validators.js
+++ b/src/validators/bajo-stock.validators.js
@@ -1,15 +1,6 @@
-const { body, query } = require('express-validator');
+const { query } = require('express-validator');
 
-// Validaciones para crear/editar productos
-exports.productValidator = [
-  body('nombre').notEmpty().withMessage('El nombre es obligatorio'),
-  body('precio').isFloat({ gt: 0 }).withMessage('Precio debe ser mayor a 0'),
-  body('stock').isInt({ min: 0 }).withMessage('Stock inválido'),
-  body('stock_minimo').isInt({ min: 0 }).withMessage('Stock mínimo inválido'),
-  body('localizacion_id').isInt().withMessage('Seleccione una localización válida')
-];
-
-// Filtros opcionales para listados de productos
+// Filtros opcionales para listado de bajo stock
 const SORT_BY = ['id', 'nombre', 'precio', 'stock', 'stock_minimo'];
 const SORT_DIR = ['asc', 'desc'];
 const OPS = ['eq', 'lte', 'gte'];
@@ -26,6 +17,5 @@ exports.listFilters = [
   query('min').optional({ checkFalsy: true }).isFloat().toFloat(),
   query('localizacionId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt(),
   query('categoriaId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt(),
-  query('proveedorId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt(),
-  query('low').optional({ checkFalsy: true }).isIn(['1'])
+  query('proveedorId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt()
 ];

--- a/src/views/layouts/layout.ejs
+++ b/src/views/layouts/layout.ejs
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= title ? title + ' — ' : '' %>Inventario</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="/css/styles.css">
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+      <%- include('../partials/head') %>
+      <link rel="stylesheet" href="/css/styles.css">
   </head>
   <body>
     <%- include('../partials/header') %>

--- a/src/views/pages/bajo-stock.ejs
+++ b/src/views/pages/bajo-stock.ejs
@@ -1,84 +1,95 @@
 <h1>Bajo stock</h1>
-<form method="get" class="row g-2 mb-3">
-  <div class="col-md-3">
-    <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= filters.qName || '' %>">
-  </div>
-  <div class="col-md-3">
-    <div class="input-group">
-      <select name="priceOp" class="form-select">
-        <option value="">Precio</option>
-        <option value="eq" <%= filters.priceOp==='eq'?'selected':'' %>>=</option>
-        <option value="lte" <%= filters.priceOp==='lte'?'selected':'' %>><=</option>
-        <option value="gte" <%= filters.priceOp==='gte'?'selected':'' %>>>=</option>
-      </select>
-      <input type="number" step="0.01" name="price" class="form-control" value="<%= filters.price || '' %>">
+<button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
+<div id="searchBox" class="collapse <%= (Object.keys(query||{}).length ? 'show' : '') %>">
+  <% if (errors && errors.length) { %>
+    <div class="alert alert-warning">
+      <strong>Revisa los filtros:</strong>
+      <ul class="mb-0">
+        <% errors.forEach(e => { %><li><%= e.path %>: <%= e.msg %></li><% }) %>
+      </ul>
     </div>
-  </div>
-  <div class="col-md-3">
-    <div class="input-group">
-      <select name="stockOp" class="form-select">
-        <option value="">Stock</option>
-        <option value="eq" <%= filters.stockOp==='eq'?'selected':'' %>>=</option>
-        <option value="lte" <%= filters.stockOp==='lte'?'selected':'' %>><=</option>
-        <option value="gte" <%= filters.stockOp==='gte'?'selected':'' %>>>=</option>
-      </select>
-      <input type="number" name="stock" class="form-control" value="<%= filters.stock || '' %>">
+  <% } %>
+  <form method="get" class="row g-2 mb-3">
+    <div class="col-md-3">
+      <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= query.qName || '' %>">
     </div>
-  </div>
-  <div class="col-md-3">
-    <div class="input-group">
-      <select name="minOp" class="form-select">
-        <option value="">Stock mín</option>
-        <option value="eq" <%= filters.minOp==='eq'?'selected':'' %>>=</option>
-        <option value="lte" <%= filters.minOp==='lte'?'selected':'' %>><=</option>
-        <option value="gte" <%= filters.minOp==='gte'?'selected':'' %>>>=</option>
-      </select>
-      <input type="number" name="min" class="form-control" value="<%= filters.min || '' %>">
+    <div class="col-md-3">
+      <div class="input-group">
+        <select name="priceOp" class="form-select">
+          <option value="">Precio</option>
+          <option value="eq" <%= query.priceOp==='eq'?'selected':'' %>>=</option>
+          <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>><=</option>
+          <option value="gte" <%= query.priceOp==='gte'?'selected':'' %>>>=</option>
+        </select>
+        <input type="number" step="0.01" name="price" class="form-control" value="<%= query.price || '' %>">
+      </div>
     </div>
-  </div>
-  <div class="col-md-3">
-    <select name="localizacionId" class="form-select">
-      <option value="">Localización</option>
-      <% localizaciones.forEach(l => { %>
-        <option value="<%= l.id %>" <%= Number(filters.localizacionId) === l.id ? 'selected' : '' %>><%= l.nombre %></option>
-      <% }) %>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <select name="categoriaId" class="form-select">
-      <option value="">Categoría</option>
-      <% categorias.forEach(c => { %>
-        <option value="<%= c.id %>" <%= Number(filters.categoriaId) === c.id ? 'selected' : '' %>><%= c.nombre %></option>
-      <% }) %>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <select name="proveedorId" class="form-select">
-      <option value="">Proveedor</option>
-      <% proveedores.forEach(p => { %>
-        <option value="<%= p.id %>" <%= Number(filters.proveedorId) === p.id ? 'selected' : '' %>><%= p.nombre %></option>
-      <% }) %>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <select name="sortBy" class="form-select">
-      <option value="id" <%= (filters.sortBy || 'id')==='id' ? 'selected' : '' %>>Ordenar por ID</option>
-      <option value="nombre" <%= filters.sortBy==='nombre'?'selected':'' %>>Nombre</option>
-      <option value="precio" <%= filters.sortBy==='precio'?'selected':'' %>>Precio</option>
-      <option value="stock" <%= filters.sortBy==='stock'?'selected':'' %>>Stock</option>
-      <option value="stock_minimo" <%= filters.sortBy==='stock_minimo'?'selected':'' %>>Stock mínimo</option>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <select name="sortDir" class="form-select">
-      <option value="asc" <%= (filters.sortDir || 'asc')==='asc' ? 'selected' : '' %>>Asc</option>
-      <option value="desc" <%= (filters.sortDir || 'asc')==='desc' ? 'selected' : '' %>>Desc</option>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <button type="submit" class="btn btn-primary w-100">Aplicar</button>
-  </div>
-</form>
+    <div class="col-md-3">
+      <div class="input-group">
+        <select name="stockOp" class="form-select">
+          <option value="">Stock</option>
+          <option value="eq" <%= query.stockOp==='eq'?'selected':'' %>>=</option>
+          <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>><=</option>
+          <option value="gte" <%= query.stockOp==='gte'?'selected':'' %>>>=</option>
+        </select>
+        <input type="number" name="stock" class="form-control" value="<%= query.stock || '' %>">
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="input-group">
+        <select name="minOp" class="form-select">
+          <option value="">Stock mín</option>
+          <option value="eq" <%= query.minOp==='eq'?'selected':'' %>>=</option>
+          <option value="lte" <%= query.minOp==='lte'?'selected':'' %>><=</option>
+          <option value="gte" <%= query.minOp==='gte'?'selected':'' %>>>=</option>
+        </select>
+        <input type="number" name="min" class="form-control" value="<%= query.min || '' %>">
+      </div>
+    </div>
+    <div class="col-md-3">
+      <select name="localizacionId" class="form-select">
+        <option value="">Localización</option>
+        <% localizaciones.forEach(l => { %>
+          <option value="<%= l.id %>" <%= Number(query.localizacionId) === l.id ? 'selected' : '' %>><%= l.nombre %></option>
+        <% }) %>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <select name="categoriaId" class="form-select">
+        <option value="">Categoría</option>
+        <% categorias.forEach(c => { %>
+          <option value="<%= c.id %>" <%= Number(query.categoriaId) === c.id ? 'selected' : '' %>><%= c.nombre %></option>
+        <% }) %>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <select name="proveedorId" class="form-select">
+        <option value="">Proveedor</option>
+        <% proveedores.forEach(p => { %>
+          <option value="<%= p.id %>" <%= Number(query.proveedorId) === p.id ? 'selected' : '' %>><%= p.nombre %></option>
+        <% }) %>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <select name="sortBy" class="form-select">
+        <option value="id" <%= (query.sortBy || 'id')==='id' ? 'selected' : '' %>>Ordenar por ID</option>
+        <option value="nombre" <%= query.sortBy==='nombre'?'selected':'' %>>Nombre</option>
+        <option value="precio" <%= query.sortBy==='precio'?'selected':'' %>>Precio</option>
+        <option value="stock" <%= query.sortBy==='stock'?'selected':'' %>>Stock</option>
+        <option value="stock_minimo" <%= query.sortBy==='stock_minimo'?'selected':'' %>>Stock mínimo</option>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <select name="sortDir" class="form-select">
+        <option value="asc" <%= (query.sortDir || 'asc')==='asc' ? 'selected' : '' %>>Asc</option>
+        <option value="desc" <%= (query.sortDir || 'asc')==='desc' ? 'selected' : '' %>>Desc</option>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <button type="submit" class="btn btn-primary w-100">Aplicar</button>
+    </div>
+  </form>
+</div>
 <table class="table table-striped">
   <thead>
     <tr>
@@ -108,7 +119,7 @@
   </tbody>
 </table>
 <%
-  const params = new URLSearchParams(filters);
+  const params = new URLSearchParams(query);
 %>
 <nav>
   <ul class="pagination">

--- a/src/views/pages/panel.ejs
+++ b/src/views/pages/panel.ejs
@@ -3,7 +3,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='<%= icons.productos %> fs-1'></i>
+          <i class="tile-icon <%= icons.productos %>"></i>
         <p class="display-6"><%= counts.productos %></p>
         <p class="text-muted mb-0">Productos</p>
       </div>
@@ -12,7 +12,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='<%= icons.categorias %> fs-1'></i>
+          <i class="tile-icon <%= icons.categorias %>"></i>
         <p class="display-6"><%= counts.categorias %></p>
         <p class="text-muted mb-0">Categorías</p>
       </div>
@@ -21,7 +21,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='<%= icons.proveedores %> fs-1'></i>
+          <i class="tile-icon <%= icons.proveedores %>"></i>
         <p class="display-6"><%= counts.proveedores %></p>
         <p class="text-muted mb-0">Proveedores</p>
       </div>
@@ -30,7 +30,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='<%= icons.localizaciones %> fs-1'></i>
+          <i class="tile-icon <%= icons.localizaciones %>"></i>
         <p class="display-6"><%= counts.localizaciones %></p>
         <p class="text-muted mb-0">Localizaciones</p>
       </div>
@@ -39,7 +39,7 @@
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100">
       <div class="card-body">
-        <i class='<%= icons.bajoStock %> fs-1'></i>
+          <i class="tile-icon <%= icons.bajoStock %>"></i>
         <p class="display-6"><%= counts.bajoStock %></p>
         <p class="text-muted mb-0">Bajo stock</p>
       </div>
@@ -49,7 +49,7 @@
     <div class="col-6 col-md-4 col-lg-2">
       <div class="card text-center h-100">
         <div class="card-body">
-          <i class='<%= icons.usuarios %> fs-1'></i>
+          <i class="tile-icon <%= icons.usuarios %>"></i>
           <p class="display-6"><%= counts.usuarios %></p>
           <p class="text-muted mb-0">Usuarios</p>
         </div>
@@ -58,7 +58,7 @@
     <div class="col-6 col-md-4 col-lg-2">
       <div class="card text-center h-100">
         <div class="card-body">
-          <i class='<%= icons.admins %> fs-1'></i>
+          <i class="tile-icon <%= icons.admins %>"></i>
           <p class="display-6"><%= counts.admins %></p>
           <p class="text-muted mb-0">Admins</p>
         </div>

--- a/src/views/pages/productos/list.ejs
+++ b/src/views/pages/productos/list.ejs
@@ -1,91 +1,102 @@
 <h1>Productos</h1>
 <a href="/productos/nuevo" class="btn btn-success mb-3">Nuevo</a>
-<form method="get" class="row g-2 mb-3">
-  <div class="col-md-3">
-    <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= filters.qName || '' %>">
-  </div>
-  <div class="col-md-3">
-    <div class="input-group">
-      <select name="priceOp" class="form-select">
-        <option value="">Precio</option>
-        <option value="eq" <%= filters.priceOp==='eq'?'selected':'' %>>=</option>
-        <option value="lte" <%= filters.priceOp==='lte'?'selected':'' %>><=</option>
-        <option value="gte" <%= filters.priceOp==='gte'?'selected':'' %>>>=</option>
+<button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
+<div id="searchBox" class="collapse <%= (Object.keys(query||{}).length ? 'show' : '') %>">
+  <% if (errors && errors.length) { %>
+    <div class="alert alert-warning">
+      <strong>Revisa los filtros:</strong>
+      <ul class="mb-0">
+        <% errors.forEach(e => { %><li><%= e.path %>: <%= e.msg %></li><% }) %>
+      </ul>
+    </div>
+  <% } %>
+  <form method="get" class="row g-2 mb-3">
+    <div class="col-md-3">
+      <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= query.qName || '' %>">
+    </div>
+    <div class="col-md-3">
+      <div class="input-group">
+        <select name="priceOp" class="form-select">
+          <option value="">Precio</option>
+          <option value="eq" <%= query.priceOp==='eq'?'selected':'' %>>=</option>
+          <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>><=</option>
+          <option value="gte" <%= query.priceOp==='gte'?'selected':'' %>>>=</option>
+        </select>
+        <input type="number" step="0.01" name="price" class="form-control" value="<%= query.price || '' %>">
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="input-group">
+        <select name="stockOp" class="form-select">
+          <option value="">Stock</option>
+          <option value="eq" <%= query.stockOp==='eq'?'selected':'' %>>=</option>
+          <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>><=</option>
+          <option value="gte" <%= query.stockOp==='gte'?'selected':'' %>>>=</option>
+        </select>
+        <input type="number" name="stock" class="form-control" value="<%= query.stock || '' %>">
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="input-group">
+        <select name="minOp" class="form-select">
+          <option value="">Stock mín</option>
+          <option value="eq" <%= query.minOp==='eq'?'selected':'' %>>=</option>
+          <option value="lte" <%= query.minOp==='lte'?'selected':'' %>><=</option>
+          <option value="gte" <%= query.minOp==='gte'?'selected':'' %>>>=</option>
+        </select>
+        <input type="number" name="min" class="form-control" value="<%= query.min || '' %>">
+      </div>
+    </div>
+    <div class="col-md-3">
+      <select name="localizacionId" class="form-select">
+        <option value="">Localización</option>
+        <% localizaciones.forEach(l => { %>
+          <option value="<%= l.id %>" <%= Number(query.localizacionId) === l.id ? 'selected' : '' %>><%= l.nombre %></option>
+        <% }) %>
       </select>
-      <input type="number" step="0.01" name="price" class="form-control" value="<%= filters.price || '' %>">
     </div>
-  </div>
-  <div class="col-md-3">
-    <div class="input-group">
-      <select name="stockOp" class="form-select">
-        <option value="">Stock</option>
-        <option value="eq" <%= filters.stockOp==='eq'?'selected':'' %>>=</option>
-        <option value="lte" <%= filters.stockOp==='lte'?'selected':'' %>><=</option>
-        <option value="gte" <%= filters.stockOp==='gte'?'selected':'' %>>>=</option>
+    <div class="col-md-3">
+      <select name="categoriaId" class="form-select">
+        <option value="">Categoría</option>
+        <% categorias.forEach(c => { %>
+          <option value="<%= c.id %>" <%= Number(query.categoriaId) === c.id ? 'selected' : '' %>><%= c.nombre %></option>
+        <% }) %>
       </select>
-      <input type="number" name="stock" class="form-control" value="<%= filters.stock || '' %>">
     </div>
-  </div>
-  <div class="col-md-3">
-    <div class="input-group">
-      <select name="minOp" class="form-select">
-        <option value="">Stock mín</option>
-        <option value="eq" <%= filters.minOp==='eq'?'selected':'' %>>=</option>
-        <option value="lte" <%= filters.minOp==='lte'?'selected':'' %>><=</option>
-        <option value="gte" <%= filters.minOp==='gte'?'selected':'' %>>>=</option>
+    <div class="col-md-3">
+      <select name="proveedorId" class="form-select">
+        <option value="">Proveedor</option>
+        <% proveedores.forEach(p => { %>
+          <option value="<%= p.id %>" <%= Number(query.proveedorId) === p.id ? 'selected' : '' %>><%= p.nombre %></option>
+        <% }) %>
       </select>
-      <input type="number" name="min" class="form-control" value="<%= filters.min || '' %>">
     </div>
-  </div>
-  <div class="col-md-3">
-    <select name="localizacionId" class="form-select">
-      <option value="">Localización</option>
-      <% localizaciones.forEach(l => { %>
-        <option value="<%= l.id %>" <%= Number(filters.localizacionId) === l.id ? 'selected' : '' %>><%= l.nombre %></option>
-      <% }) %>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <select name="categoriaId" class="form-select">
-      <option value="">Categoría</option>
-      <% categorias.forEach(c => { %>
-        <option value="<%= c.id %>" <%= Number(filters.categoriaId) === c.id ? 'selected' : '' %>><%= c.nombre %></option>
-      <% }) %>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <select name="proveedorId" class="form-select">
-      <option value="">Proveedor</option>
-      <% proveedores.forEach(p => { %>
-        <option value="<%= p.id %>" <%= Number(filters.proveedorId) === p.id ? 'selected' : '' %>><%= p.nombre %></option>
-      <% }) %>
-    </select>
-  </div>
-  <div class="col-md-3 d-flex align-items-center">
-    <div class="form-check">
-      <input class="form-check-input" type="checkbox" name="low" value="1" id="lowChk" <%= filters.low === '1' ? 'checked' : '' %>>
-      <label class="form-check-label" for="lowChk">Bajo stock</label>
+    <div class="col-md-3 d-flex align-items-center">
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" name="low" value="1" id="lowChk" <%= query.low === '1' ? 'checked' : '' %>>
+        <label class="form-check-label" for="lowChk">Bajo stock</label>
+      </div>
     </div>
-  </div>
-  <div class="col-md-3">
-    <select name="sortBy" class="form-select">
-      <option value="id" <%= (filters.sortBy || 'id')==='id' ? 'selected' : '' %>>Ordenar por ID</option>
-      <option value="nombre" <%= filters.sortBy==='nombre'?'selected':'' %>>Nombre</option>
-      <option value="precio" <%= filters.sortBy==='precio'?'selected':'' %>>Precio</option>
-      <option value="stock" <%= filters.sortBy==='stock'?'selected':'' %>>Stock</option>
-      <option value="stock_minimo" <%= filters.sortBy==='stock_minimo'?'selected':'' %>>Stock mínimo</option>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <select name="sortDir" class="form-select">
-      <option value="asc" <%= (filters.sortDir || 'asc')==='asc' ? 'selected' : '' %>>Asc</option>
-      <option value="desc" <%= (filters.sortDir || 'asc')==='desc' ? 'selected' : '' %>>Desc</option>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <button type="submit" class="btn btn-primary w-100">Aplicar</button>
-  </div>
-</form>
+    <div class="col-md-3">
+      <select name="sortBy" class="form-select">
+        <option value="id" <%= (query.sortBy || 'id')==='id' ? 'selected' : '' %>>Ordenar por ID</option>
+        <option value="nombre" <%= query.sortBy==='nombre'?'selected':'' %>>Nombre</option>
+        <option value="precio" <%= query.sortBy==='precio'?'selected':'' %>>Precio</option>
+        <option value="stock" <%= query.sortBy==='stock'?'selected':'' %>>Stock</option>
+        <option value="stock_minimo" <%= query.sortBy==='stock_minimo'?'selected':'' %>>Stock mínimo</option>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <select name="sortDir" class="form-select">
+        <option value="asc" <%= (query.sortDir || 'asc')==='asc' ? 'selected' : '' %>>Asc</option>
+        <option value="desc" <%= (query.sortDir || 'asc')==='desc' ? 'selected' : '' %>>Desc</option>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <button type="submit" class="btn btn-primary w-100">Aplicar</button>
+    </div>
+  </form>
+</div>
 <table class="table table-striped">
   <thead>
     <tr>
@@ -116,8 +127,8 @@
     <% }) %>
   </tbody>
 </table>
-<%
-  const params = new URLSearchParams(filters);
+<% 
+  const params = new URLSearchParams(query);
 %>
 <nav>
   <ul class="pagination">

--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -1,0 +1,1 @@
+<link href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css" rel="stylesheet">

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -9,23 +9,23 @@
         <% } %>
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
           <% if (isAuthenticated) { %>
-            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/panel') ? 'active' : '' %>" href="/panel">Panel</a></li>
-            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/productos') ? 'active' : '' %>" href="/productos">Productos</a></li>
-            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/categorias') ? 'active' : '' %>" href="/categorias">Categorías</a></li>
-            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/proveedores') ? 'active' : '' %>" href="/proveedores">Proveedores</a></li>
-            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/localizaciones') ? 'active' : '' %>" href="/localizaciones">Localizaciones</a></li>
-            <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/inventario/bajo-stock') ? 'active' : '' %>" href="/inventario/bajo-stock">Bajo stock</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/panel') ? 'active' : '' %>" href="/panel">Panel</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/productos') ? 'active' : '' %>" href="/productos">Productos</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/categorias') ? 'active' : '' %>" href="/categorias">Categorías</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/proveedores') ? 'active' : '' %>" href="/proveedores">Proveedores</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/localizaciones') ? 'active' : '' %>" href="/localizaciones">Localizaciones</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/inventario/bajo-stock') ? 'active' : '' %>" href="/inventario/bajo-stock">Bajo stock</a></li>
             <% if (userRole === 'admin') { %>
-              <li class="nav-item"><a class="nav-link <%= currentPath.startsWith('/usuarios') ? 'active' : '' %>" href="/usuarios">Usuarios</a></li>
+                <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/usuarios') ? 'active' : '' %>" href="/usuarios">Usuarios</a></li>
             <% } %>
           <% } %>
         </ul>
         <ul class="navbar-nav">
           <% if (isAuthenticated) { %>
             <li class="nav-item d-none d-lg-block"><span class="navbar-text me-3">👋 Hola, <strong><%= userName %></strong> (<%= userRole %>)</span></li>
-            <li class="nav-item"><a class="nav-link" href="/auth/logout">Salir</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3" href="/auth/logout">Salir</a></li>
           <% } else { %>
-            <li class="nav-item"><a class="nav-link <%= currentPath === '/login' ? 'active' : '' %>" href="/login">Login</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath === '/login' ? 'active' : '' %>" href="/login">Login</a></li>
           <% } %>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- sanitize optional query filters for product and low-stock lists
- add collapsible search panel with persistent filters and error alerts
- fix providers icon and unify nav/icon styles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b79eab0168832a8e7a8bf2e6fbc11e