### PR TITLE
feat: enhance search filters and collapse behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ En XAMPP/MAMP el usuario `root` suele ir sin contraseña → deja `DB_PASSWORD` 
 - Panel de inventario con contadores.
 - Navbar responsive con saludo y enlaces activos.
 - Títulos dinámicos por vista.
-- Listados con filtros opcionales y panel de búsqueda plegable.
+- Panel de búsqueda plegable con botón **Buscar** que abre/cierra manualmente y acción **Limpiar** para reiniciar filtros.
 - Navegación de detalle con parámetro `returnTo` para conservar filtros.
 - Mensajes flash con SweetAlert2 para login y acciones críticas.
 - Columnas de costo y observaciones en productos y bajo stock con tooltips.
@@ -140,6 +140,7 @@ Los enlaces de **Detalles** agregan `returnTo=<URL>` y el botón **Volver** en e
 
 ## Filtros y ordenación
 `GET /productos` y `GET /inventario/bajo-stock` aceptan filtros por nombre (`qName`), comparadores `priceOp`/`price`, `stockOp`/`stock`, `minOp`/`min`, relaciones (`localizacionId`, `categoriaId`, `proveedorId`), ordenación (`sortBy`, `sortDir`) y el flag `low=1` en productos.
+  - Si se envía un valor numérico sin operador, el backend asume `=` por defecto.
 
 ## Títulos dinámicos
 El layout define `<title><%= title ? title + ' — ' : '' %>Inventario</title>` para que cada vista establezca su propio título.
@@ -178,8 +179,13 @@ El layout define `<title><%= title ? title + ' — ' : '' %>Inventario</title>` 
 - Listado de usuarios muestra columna Teléfono y permite filtrar por ID, nombre, email, rol y teléfono.
 - Búsquedas por ID y nombre funcionan en categorías, proveedores y localizaciones.
 - Creación y edición de productos permiten seleccionar múltiples categorías y proveedores.
+- Productos: abrir **Buscar**, aplicar varios filtros y luego pulsar **Limpiar** para volver a la ruta base sin query.
+- Con filtros activos, cambiar a otra página de resultados y comprobar que el panel de búsqueda permanece cerrado.
+- Ingresar precio/stock/stock mín con valor pero sin operador → el filtrado usa `=` por defecto.
+- Bajo stock: repetir las mismas pruebas que en Productos.
 
 ## Changelog
+- Botón **Limpiar** en búsquedas, collapse cerrado por defecto y operadores numéricos con `=` por defecto.
 - Añadido SweetAlert2 y middleware flash.
 - Incorporados campos costo y observaciones en productos y bajo stock con tooltips.
 - Detalle de producto ampliado con costo y observaciones.
@@ -272,3 +278,7 @@ Revisa inputs de formularios con express-validator (servidor) además de validac
 - Panel de búsqueda plegable con filtros opcionales y validación amigable en Productos y Bajo stock.
 - Icono de Proveedores corregido y estilos unificados de iconos.
 - `returnTo` preserva filtros al navegar al detalle.
+
+### 2025-10-05
+- Botón **Limpiar** en paneles de búsqueda y collapse cerrado por defecto.
+- Operadores de precio/stock usan `=` si no se selecciona ninguno.

--- a/src/utils/sql.js
+++ b/src/utils/sql.js
@@ -1,0 +1,28 @@
+/**
+ * Utilidades para construir cláusulas SQL de manera segura.
+ * Centraliza el mapeo de operadores permitidos y funciones helper.
+ */
+
+// Mapa whitelist de operadores disponibles en los filtros
+const OPERATOR_SQL = { eq: '=', lte: '<=', gte: '>=' };
+
+// Lista de claves admitidas, útil para validación con express-validator
+const OPERATOR_KEYS = Object.keys(OPERATOR_SQL);
+
+/**
+ * Añade a los acumuladores una condición numérica comparando un campo con un valor.
+ * Si no se indica un operador válido, se usa '=' por defecto.
+ * @param {string[]} clauses - Array que acumula las cláusulas WHERE.
+ * @param {Array} params - Array que acumula los valores parametrizados.
+ * @param {string} fieldSql - Nombre del campo SQL (ya validado en whitelist).
+ * @param {number|string} value - Valor numérico enviado por el usuario.
+ * @param {string} opKey - Clave del operador recibido ('eq', 'lte', 'gte').
+ */
+function addNumericFilter(clauses, params, fieldSql, value, opKey) {
+  if (value == null || value === '') return; // No hay valor: no se agrega condición
+  const op = OPERATOR_SQL[opKey] || '='; // Operador seguro con '=' por defecto
+  clauses.push(`${fieldSql} ${op} ?`);
+  params.push(Number(value)); // Conversión a número para evitar inyecciones
+}
+
+module.exports = { OPERATOR_SQL, OPERATOR_KEYS, addNumericFilter };

--- a/src/validators/bajo-stock.validators.js
+++ b/src/validators/bajo-stock.validators.js
@@ -1,20 +1,27 @@
 const { query } = require('express-validator');
+const { OPERATOR_KEYS } = require('../utils/sql'); // Operadores válidos para comparaciones
 
 // Filtros opcionales para listado de bajo stock
 const SORT_BY = ['id', 'nombre', 'precio', 'stock', 'stock_minimo'];
 const SORT_DIR = ['asc', 'desc'];
-const OPS = ['eq', 'lte', 'gte'];
+const OPS = OPERATOR_KEYS; // ['eq','lte','gte']
 
+// Validaciones para filtros opcionales del listado de bajo stock
+// Cada parámetro se ignora si no se envía; el controlador aplicará '=' por defecto para comparaciones numéricas.
 exports.listFilters = [
+  // Ordenación
   query('sortBy').optional({ checkFalsy: true }).toLowerCase().custom(v => SORT_BY.includes(v) ? v : undefined),
   query('sortDir').optional({ checkFalsy: true }).toLowerCase().custom(v => SORT_DIR.includes(v) ? v : undefined),
+  // Búsqueda por nombre
   query('qName').optional({ checkFalsy: true }).trim().isLength({ min: 1, max: 200 }),
+  // Comparaciones numéricas
   query('priceOp').optional({ checkFalsy: true }).isIn(OPS),
   query('price').optional({ checkFalsy: true }).isFloat().toFloat(),
   query('stockOp').optional({ checkFalsy: true }).isIn(OPS),
   query('stock').optional({ checkFalsy: true }).isFloat().toFloat(),
   query('minOp').optional({ checkFalsy: true }).isIn(OPS),
   query('min').optional({ checkFalsy: true }).isFloat().toFloat(),
+  // Filtros por relaciones
   query('localizacionId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt(),
   query('categoriaId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt(),
   query('proveedorId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt()

--- a/src/validators/productos.validators.js
+++ b/src/validators/productos.validators.js
@@ -1,4 +1,5 @@
 const { body, query } = require('express-validator');
+const { OPERATOR_KEYS } = require('../utils/sql'); // Operadores permitidos para comparaciones numéricas
 
 // Validaciones para crear/editar productos
 exports.productValidator = [
@@ -15,22 +16,29 @@ exports.productValidator = [
 ];
 
 // Filtros opcionales para listados de productos
+// Cada parámetro en la query se valida y, si no se envía, se omite.
+// El controlador aplicará '=' por defecto cuando haya valor pero falte operador.
 const SORT_BY = ['id', 'nombre', 'precio', 'stock', 'stock_minimo'];
 const SORT_DIR = ['asc', 'desc'];
-const OPS = ['eq', 'lte', 'gte'];
+const OPS = OPERATOR_KEYS; // ['eq','lte','gte']
 
 exports.listFilters = [
+  // Ordenación
   query('sortBy').optional({ checkFalsy: true }).toLowerCase().custom(v => SORT_BY.includes(v) ? v : undefined),
   query('sortDir').optional({ checkFalsy: true }).toLowerCase().custom(v => SORT_DIR.includes(v) ? v : undefined),
+  // Búsqueda por nombre
   query('qName').optional({ checkFalsy: true }).trim().isLength({ min: 1, max: 200 }),
+  // Comparaciones numéricas: operador y valor son independientes
   query('priceOp').optional({ checkFalsy: true }).isIn(OPS),
   query('price').optional({ checkFalsy: true }).isFloat().toFloat(),
   query('stockOp').optional({ checkFalsy: true }).isIn(OPS),
   query('stock').optional({ checkFalsy: true }).isFloat().toFloat(),
   query('minOp').optional({ checkFalsy: true }).isIn(OPS),
   query('min').optional({ checkFalsy: true }).isFloat().toFloat(),
+  // Filtros por relaciones
   query('localizacionId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt(),
   query('categoriaId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt(),
   query('proveedorId').optional({ checkFalsy: true }).isInt({ min: 1 }).toInt(),
+  // Flag para productos con stock < stock_minimo
   query('low').optional({ checkFalsy: true }).isIn(['1'])
 ];

--- a/src/views/pages/bajo-stock.ejs
+++ b/src/views/pages/bajo-stock.ejs
@@ -1,6 +1,6 @@
 <h1>Bajo stock</h1>
 <button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
-<div id="searchBox" class="collapse <%= (Object.keys(query||{}).length ? 'show' : '') %>">
+<div id="searchBox" class="collapse"><!-- Collapse cerrado por defecto -->
   <% if (errors && errors.length) { %>
     <div class="alert alert-warning">
       <strong>Revisa los filtros:</strong>
@@ -9,42 +9,45 @@
       </ul>
     </div>
   <% } %>
-  <form method="get" class="row g-2 mb-3">
+  <form class="row g-3" method="get" action="<%= basePath %>">
     <div class="col-md-3">
       <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= query.qName || '' %>">
     </div>
     <div class="col-md-3">
       <div class="input-group">
         <select name="priceOp" class="form-select">
-          <option value="">Precio</option>
+          <option value="">Operador</option>
           <option value="eq" <%= query.priceOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.priceOp==='gte'?'selected':'' %>>>=</option>
         </select>
-        <input type="number" step="0.01" name="price" class="form-control" value="<%= query.price || '' %>">
+        <input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" value="<%= query.price || '' %>">
       </div>
+      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
       <div class="input-group">
         <select name="stockOp" class="form-select">
-          <option value="">Stock</option>
+          <option value="">Operador</option>
           <option value="eq" <%= query.stockOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.stockOp==='gte'?'selected':'' %>>>=</option>
         </select>
-        <input type="number" name="stock" class="form-control" value="<%= query.stock || '' %>">
+        <input type="number" name="stock" class="form-control" placeholder="Stock" value="<%= query.stock || '' %>">
       </div>
+      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
       <div class="input-group">
         <select name="minOp" class="form-select">
-          <option value="">Stock mín</option>
+          <option value="">Operador</option>
           <option value="eq" <%= query.minOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.minOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.minOp==='gte'?'selected':'' %>>>=</option>
         </select>
-        <input type="number" name="min" class="form-control" value="<%= query.min || '' %>">
+        <input type="number" name="min" class="form-control" placeholder="Stock mín" value="<%= query.min || '' %>">
       </div>
+      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
       <select name="localizacionId" class="form-select">
@@ -85,8 +88,9 @@
         <option value="desc" <%= (query.sortDir || 'asc')==='desc' ? 'selected' : '' %>>Desc</option>
       </select>
     </div>
-    <div class="col-md-3">
-      <button type="submit" class="btn btn-primary w-100">Aplicar</button>
+    <div class="col-12 d-flex gap-2">
+      <button class="btn btn-primary" type="submit">Aplicar</button>
+      <a class="btn btn-outline-secondary" href="<%= basePath %>">Limpiar</a>
     </div>
   </form>
 </div>
@@ -138,7 +142,7 @@
 <nav>
   <ul class="pagination">
     <% for(let i=1;i<=totalPages;i++){ params.set('page', i); %>
-      <li class="page-item <%= i===page ? 'active' : '' %>"><a class="page-link" href="?<%= params.toString() %>"><%= i %></a></li>
+      <li class="page-item <%= i===page ? 'active' : '' %>"><a class="page-link" href="<%= basePath %>?<%= params.toString() %>"><%= i %></a></li>
     <% } %>
   </ul>
 </nav>

--- a/src/views/pages/productos/list.ejs
+++ b/src/views/pages/productos/list.ejs
@@ -1,7 +1,7 @@
 <h1>Productos</h1>
 <a href="/productos/nuevo" class="btn btn-success mb-3">Nuevo</a>
 <button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
-<div id="searchBox" class="collapse <%= (Object.keys(query||{}).length ? 'show' : '') %>">
+<div id="searchBox" class="collapse"><!-- Siempre cerrado; se abre solo al pulsar "Buscar" -->
   <% if (errors && errors.length) { %>
     <div class="alert alert-warning">
       <strong>Revisa los filtros:</strong>
@@ -10,42 +10,46 @@
       </ul>
     </div>
   <% } %>
-  <form method="get" class="row g-2 mb-3">
+  <!-- Filtros de búsqueda. Envían GET a la ruta base y mantienen valores actuales -->
+  <form class="row g-3" method="get" action="<%= basePath %>">
     <div class="col-md-3">
       <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= query.qName || '' %>">
     </div>
     <div class="col-md-3">
       <div class="input-group">
         <select name="priceOp" class="form-select">
-          <option value="">Precio</option>
+          <option value="">Operador</option>
           <option value="eq" <%= query.priceOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.priceOp==='gte'?'selected':'' %>>>=</option>
         </select>
-        <input type="number" step="0.01" name="price" class="form-control" value="<%= query.price || '' %>">
+        <input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" value="<%= query.price || '' %>">
       </div>
+      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
       <div class="input-group">
         <select name="stockOp" class="form-select">
-          <option value="">Stock</option>
+          <option value="">Operador</option>
           <option value="eq" <%= query.stockOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.stockOp==='gte'?'selected':'' %>>>=</option>
         </select>
-        <input type="number" name="stock" class="form-control" value="<%= query.stock || '' %>">
+        <input type="number" name="stock" class="form-control" placeholder="Stock" value="<%= query.stock || '' %>">
       </div>
+      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
       <div class="input-group">
         <select name="minOp" class="form-select">
-          <option value="">Stock mín</option>
+          <option value="">Operador</option>
           <option value="eq" <%= query.minOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.minOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.minOp==='gte'?'selected':'' %>>>=</option>
         </select>
-        <input type="number" name="min" class="form-control" value="<%= query.min || '' %>">
+        <input type="number" name="min" class="form-control" placeholder="Stock mín" value="<%= query.min || '' %>">
       </div>
+      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
       <select name="localizacionId" class="form-select">
@@ -92,8 +96,10 @@
         <option value="desc" <%= (query.sortDir || 'asc')==='desc' ? 'selected' : '' %>>Desc</option>
       </select>
     </div>
-    <div class="col-md-3">
-      <button type="submit" class="btn btn-primary w-100">Aplicar</button>
+    <!-- Botones de acción: aplicar filtros o volver a la ruta base -->
+    <div class="col-12 d-flex gap-2">
+      <button class="btn btn-primary" type="submit">Aplicar</button>
+      <a class="btn btn-outline-secondary" href="<%= basePath %>">Limpiar</a>
     </div>
   </form>
 </div>
@@ -147,7 +153,7 @@
 <nav>
   <ul class="pagination">
     <% for(let i=1;i<=totalPages;i++){ params.set('page', i); %>
-      <li class="page-item <%= i===page ? 'active' : '' %>"><a class="page-link" href="?<%= params.toString() %>"><%= i %></a></li>
+      <li class="page-item <%= i===page ? 'active' : '' %>"><a class="page-link" href="<%= basePath %>?<%= params.toString() %>"><%= i %></a></li>
     <% } %>
   </ul>
 </nav>


### PR DESCRIPTION
## Summary
- add reusable SQL helper and default '=' operator handling
- keep search collapses closed by default and add 'Limpiar' reset links
- document new filter behavior and manual tests

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68bf05cdaf7c832a94000208d6213ae0