### PR TITLE
feat: operator popup and visual refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Aplicación de gestión de inventario pensada para prácticas del módulo 2. Incluye login con roles, CRUDs completos y panel con métricas.
 
+## Histórico anterior (resumen)
+- Corrección de vistas EJS y layouts.
+- Reestructuración inicial del proyecto y semillas SQL.
+- Filtros y ordenación con operadores numéricos.
+- Checkboxes en nuevo producto.
+- SweetAlert2 en login.
+- Fixes de operadores y contadores del panel.
+- Navbar responsive y títulos dinámicos.
+
 ## Stack técnico
 - Node.js >=18
 - Express 4.19.x
@@ -126,6 +135,9 @@ Solo los usuarios con rol **admin** pueden crear, editar o eliminar otros usuari
 ## Stock vs Stock mínimo
 Los listados muestran badges comparando el stock actual con el mínimo definido: si el stock es menor al mínimo la etiqueta aparece en rojo, de lo contrario en verde.
 
+## Filtros y operadores
+Los formularios de búsqueda permiten elegir operadores '=', '≤' o '≥' para precio, stock y stock mínimo. Si se deja sin operador pero con valor, el backend asume '=' por defecto y se muestra un aviso informativo.
+
 ## Navegación “Volver”
 Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 
@@ -146,11 +158,11 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 - [ ] Auditoría de producción sin vulnerabilidades críticas.
 
 ## Pruebas manuales sugeridas
-1. Acceder al panel y verificar contadores.
-2. Crear/editar productos y comprobar listado de **bajo stock**.
-3. Crear usuarios (solo admin) y validar teléfonos.
-4. Revisar la navbar responsive en distintos tamaños.
-5. Confirmar títulos dinámicos en varias vistas.
+1. Acceder al panel y verificar contadores e iconos.
+2. En Productos, buscar con precio/stock/mín sin operador: aparece popup informativo solo una vez; ejecutar búsqueda usa '='.
+3. En Bajo stock, repetir la prueba anterior.
+4. En cualquier listado, ordenar por Costo y comprobar el orden.
+5. Revisar navbar y subheaders en distintas vistas; títulos dinámicos.
 
 ## Troubleshooting
 - **DB access denied**: revisa credenciales y privilegios MySQL.
@@ -162,6 +174,12 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 - **Errores al importar seeds**: asegúrate de que la base existe y de tener permisos.
 
 ## CHANGELOG
+## [2025-09-08 19:25] – Popup de operadores, ordenar por costo, estilo visual y README restaurado
+- Añadido popup (SweetAlert2) y tooltip para operadores en productos y bajo stock; backend mantiene '=' por defecto si no se elige operador.
+- “Ordenar por…” ampliado con Costo y campos pendientes; validación/whitelist en controladores/validators.
+- Estilo visual renovado con CSS variables, cards de resumen con iconos SVG (sin binarios), navbar y subheaders diferenciados.
+- README restaurado y unificado: se recuperan/recapitulán changelogs previos y se documenta esta iteración.
+
 ### [2025-09-08 18:35] – Eliminación de nodemon y saneado de vulnerabilidades
 - Eliminado nodemon y devDependencies asociadas.
 - Estabilizado stack en Express 4.19.x + express-session ^1.18.0.

--- a/src/controllers/bajo-stock.controller.js
+++ b/src/controllers/bajo-stock.controller.js
@@ -11,12 +11,14 @@ exports.list = async (req, res) => {
   const limit = 10;                           // Elementos por página
   const offset = (page - 1) * limit;          // Desplazamiento
 
-  const SORTABLE = {                          // Columnas permitidas para ordenar
+  const SORTABLE = {
     id: 'p.id',
     nombre: 'p.nombre',
     precio: 'p.precio',
+    costo: 'p.costo',
     stock: 'p.stock',
-    stock_minimo: 'p.stock_minimo'
+    stock_minimo: 'p.stock_minimo',
+    localizacion: 'l.nombre'
   };
 
   const sortCol = SORTABLE[data.sortBy] || 'p.id';

--- a/src/controllers/productos.controller.js
+++ b/src/controllers/productos.controller.js
@@ -11,12 +11,14 @@ exports.list = async (req, res) => {
   const limit = 10;                           // Elementos por página
   const offset = (page - 1) * limit;          // Desplazamiento
 
-  const SORTABLE = {                          // Map de columnas ordenables
+  const SORTABLE = {
     id: 'p.id',
     nombre: 'p.nombre',
     precio: 'p.precio',
+    costo: 'p.costo',
     stock: 'p.stock',
-    stock_minimo: 'p.stock_minimo'
+    stock_minimo: 'p.stock_minimo',
+    localizacion: 'l.nombre'
   }; // Cualquier otra columna queda descartada
 
   const sortCol = SORTABLE[data.sortBy] || 'p.id';

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1,22 +1,60 @@
-body { padding-top: 60px; }
+/* Variables de tema y colores principales */
+:root {
+  --brand:#2563eb; --accent:#10b981; --muted:#64748b;
+  --success:#22c55e; --warning:#f59e0b; --danger:#ef4444;
+  --card-bg:#ffffff; --card-border:#e5e7eb; --page-bg:#f8fafc;
+}
 
+/* Ajustes generales */
+body {
+  padding-top:60px;
+  background-color: var(--page-bg);
+}
+
+/* Navbar con enlaces activos y separación sutil */
 .navbar-identity {
-  color: #fff;
-  padding: .5rem 1rem;
-  background-color: rgba(255,255,255,0.1);
-  border-radius: .25rem;
+  color:#fff;
+  padding:.5rem 1rem;
+  background-color:rgba(255,255,255,0.1);
+  border-radius:.25rem;
 }
-
 .nav-link.active {
-  font-weight: 500;
-  border-bottom: 2px solid #fff;
-  border-radius: .25rem;
+  font-weight:500;
+  border-bottom:2px solid var(--brand);
+  border-radius:.25rem;
+  color:var(--brand)!important;
 }
+.nav-link:hover { color:var(--brand); }
+.nav-separated .nav-link + .nav-link { border-left:1px solid rgba(0,0,0,.1); }
 
-.nav-separated .nav-link + .nav-link {
-  border-left: 1px solid rgba(0,0,0,.1);
+/* Tarjetas del panel/resumen */
+.summary-card {
+  background:var(--card-bg);
+  border:1px solid var(--card-border);
+  box-shadow:0 .125rem .25rem rgba(0,0,0,.05);
+  border-left:4px solid transparent;
 }
+.border-brand{border-left-color:var(--brand)!important;}
+.border-accent{border-left-color:var(--accent)!important;}
+.border-muted{border-left-color:var(--muted)!important;}
+.border-success{border-left-color:var(--success)!important;}
+.border-warning{border-left-color:var(--warning)!important;}
+.border-danger{border-left-color:var(--danger)!important;}
+.tile-icon{
+  font-size:1.75rem;
+  width:1.75rem;
+  height:1.75rem;
+}
+.text-brand{color:var(--brand)!important;}
+.text-accent{color:var(--accent)!important;}
+.text-muted{color:var(--muted)!important;}
+.text-success{color:var(--success)!important;}
+.text-warning{color:var(--warning)!important;}
+.text-danger{color:var(--danger)!important;}
 
-.tile-icon {
-  font-size: 1.75rem;
-}
+/* Subheaders con badges de color */
+.subheader{padding:.25rem 0;}
+.badge-brand{background-color:var(--brand);}
+.badge-accent{background-color:var(--accent);}
+.badge-warning{background-color:var(--warning);}
+.badge-brand,.badge-accent,.badge-warning{color:#fff;}

--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -1,7 +1,31 @@
-// JS principal
+// Lógica global del frontend
 console.log('Inventario listo');
 
-// Tooltips
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
-// Popovers (si se necesitan)
-document.querySelectorAll('[data-bs-toggle="popover"]').forEach(el => new bootstrap.Popover(el, { trigger: 'hover', html: true }));
+// Inicialización de tooltips y popovers
+// Se aplica a cualquier elemento con los atributos data-bs-toggle correspondientes
+ document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
+ document.querySelectorAll('[data-bs-toggle="popover"]').forEach(el => new bootstrap.Popover(el, { trigger: 'hover', html: true }));
+
+// Popup informativo de operadores en formularios de búsqueda
+// Si un campo numérico tiene valor sin operador seleccionado, muestra SweetAlert
+// Solo aparece una vez por sesión y por vista usando sessionStorage
+ document.querySelectorAll('form[data-search]').forEach(form => {
+   form.addEventListener('submit', () => {
+     const key = `swalHint-${form.getAttribute('data-search')}`; // Clave única por vista
+     const priceVal = form.querySelector('[name="price"]').value;
+     const priceOp = form.querySelector('[name="priceOp"]').value;
+     const stockVal = form.querySelector('[name="stock"]').value;
+     const stockOp = form.querySelector('[name="stockOp"]').value;
+     const minVal = form.querySelector('[name="min"]').value;
+     const minOp = form.querySelector('[name="minOp"]').value;
+     if (!sessionStorage.getItem(key) && ((priceVal && !priceOp) || (stockVal && !stockOp) || (minVal && !minOp))) {
+       Swal.fire({
+         icon: 'info',
+         title: 'Operador por defecto',
+         text: "Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.",
+         confirmButtonText: 'Entendido'
+       });
+       sessionStorage.setItem(key, '1');
+     }
+   });
+ });

--- a/src/validators/bajo-stock.validators.js
+++ b/src/validators/bajo-stock.validators.js
@@ -2,7 +2,7 @@ const { query } = require('express-validator');
 const { OPERATOR_KEYS } = require('../utils/sql'); // Operadores válidos para comparaciones
 
 // Filtros opcionales para listado de bajo stock
-const SORT_BY = ['id', 'nombre', 'precio', 'stock', 'stock_minimo'];
+const SORT_BY = ['id','nombre','precio','costo','stock','stock_minimo','localizacion'];
 const SORT_DIR = ['asc', 'desc'];
 const OPS = OPERATOR_KEYS; // ['eq','lte','gte']
 

--- a/src/validators/productos.validators.js
+++ b/src/validators/productos.validators.js
@@ -18,7 +18,7 @@ exports.productValidator = [
 // Filtros opcionales para listados de productos
 // Cada parámetro en la query se valida y, si no se envía, se omite.
 // El controlador aplicará '=' por defecto cuando haya valor pero falte operador.
-const SORT_BY = ['id', 'nombre', 'precio', 'stock', 'stock_minimo'];
+const SORT_BY = ['id','nombre','precio','costo','stock','stock_minimo','localizacion'];
 const SORT_DIR = ['asc', 'desc'];
 const OPS = OPERATOR_KEYS; // ['eq','lte','gte']
 

--- a/src/views/pages/bajo-stock.ejs
+++ b/src/views/pages/bajo-stock.ejs
@@ -1,4 +1,5 @@
 <h1>Bajo stock</h1>
+<div class="subheader mb-3"><span class="badge badge-warning">Listado</span></div>
 <button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
 <div id="searchBox" class="collapse"><!-- Collapse cerrado por defecto -->
   <% if (errors && errors.length) { %>
@@ -9,11 +10,12 @@
       </ul>
     </div>
   <% } %>
-  <form class="row g-3" method="get" action="<%= basePath %>">
+  <form class="row g-3" method="get" action="<%= basePath %>" data-search="bajoStock">
     <div class="col-md-3">
       <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= query.qName || '' %>">
     </div>
     <div class="col-md-3">
+      <label class="form-label">Operador (Precio)</label>
       <div class="input-group">
         <select name="priceOp" class="form-select">
           <option value="">Operador</option>
@@ -21,11 +23,13 @@
           <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.priceOp==='gte'?'selected':'' %>>>=</option>
         </select>
+        <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" value="<%= query.price || '' %>">
       </div>
       <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
+      <label class="form-label">Operador (Stock)</label>
       <div class="input-group">
         <select name="stockOp" class="form-select">
           <option value="">Operador</option>
@@ -33,11 +37,13 @@
           <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.stockOp==='gte'?'selected':'' %>>>=</option>
         </select>
+        <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" name="stock" class="form-control" placeholder="Stock" value="<%= query.stock || '' %>">
       </div>
       <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
+      <label class="form-label">Operador (Stock mínimo)</label>
       <div class="input-group">
         <select name="minOp" class="form-select">
           <option value="">Operador</option>
@@ -45,6 +51,7 @@
           <option value="lte" <%= query.minOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.minOp==='gte'?'selected':'' %>>>=</option>
         </select>
+        <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" name="min" class="form-control" placeholder="Stock mín" value="<%= query.min || '' %>">
       </div>
       <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
@@ -78,8 +85,10 @@
         <option value="id" <%= (query.sortBy || 'id')==='id' ? 'selected' : '' %>>Ordenar por ID</option>
         <option value="nombre" <%= query.sortBy==='nombre'?'selected':'' %>>Nombre</option>
         <option value="precio" <%= query.sortBy==='precio'?'selected':'' %>>Precio</option>
+        <option value="costo" <%= query.sortBy==='costo'?'selected':'' %>>Costo</option>
         <option value="stock" <%= query.sortBy==='stock'?'selected':'' %>>Stock</option>
         <option value="stock_minimo" <%= query.sortBy==='stock_minimo'?'selected':'' %>>Stock mínimo</option>
+        <option value="localizacion" <%= query.sortBy==='localizacion'?'selected':'' %>>Localización</option>
       </select>
     </div>
     <div class="col-md-3">

--- a/src/views/pages/panel.ejs
+++ b/src/views/pages/panel.ejs
@@ -1,45 +1,51 @@
 <h1 class="mb-4">Resumen</h1>
+<div class="subheader mb-3"><span class="badge badge-accent">Panel</span></div>
 <div class="row g-3">
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100">
+    <div class="card text-center h-100 summary-card border-brand">
       <div class="card-body">
-          <i class="tile-icon <%= icons.productos %>"></i>
+        <i class="tile-icon text-brand <%= icons.productos %>"></i>
         <p class="display-6"><%= counts.productos %></p>
         <p class="text-muted mb-0">Productos</p>
       </div>
     </div>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100">
+    <div class="card text-center h-100 summary-card border-accent">
       <div class="card-body">
-          <i class="tile-icon <%= icons.categorias %>"></i>
+        <i class="tile-icon text-accent <%= icons.categorias %>"></i>
         <p class="display-6"><%= counts.categorias %></p>
         <p class="text-muted mb-0">Categorías</p>
       </div>
     </div>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100">
+    <div class="card text-center h-100 summary-card border-muted">
       <div class="card-body">
-          <i class="tile-icon <%= icons.proveedores %>"></i>
+        <svg class="tile-icon text-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <rect x="1" y="7" width="13" height="8" rx="2" ry="2"></rect>
+          <path d="M14 9h4l3 3v3h-7z"></path>
+          <circle cx="5.5" cy="18" r="1.5"></circle>
+          <circle cx="17.5" cy="18" r="1.5"></circle>
+        </svg>
         <p class="display-6"><%= counts.proveedores %></p>
         <p class="text-muted mb-0">Proveedores</p>
       </div>
     </div>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100">
+    <div class="card text-center h-100 summary-card border-success">
       <div class="card-body">
-          <i class="tile-icon <%= icons.localizaciones %>"></i>
+        <i class="tile-icon text-success <%= icons.localizaciones %>"></i>
         <p class="display-6"><%= counts.localizaciones %></p>
         <p class="text-muted mb-0">Localizaciones</p>
       </div>
     </div>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100">
+    <div class="card text-center h-100 summary-card border-warning">
       <div class="card-body">
-          <i class="tile-icon <%= icons.bajoStock %>"></i>
+        <i class="tile-icon text-warning <%= icons.bajoStock %>"></i>
         <p class="display-6"><%= counts.bajoStock %></p>
         <p class="text-muted mb-0">Bajo stock</p>
       </div>
@@ -47,18 +53,18 @@
   </div>
   <% if (isAdmin) { %>
     <div class="col-6 col-md-4 col-lg-2">
-      <div class="card text-center h-100">
+      <div class="card text-center h-100 summary-card border-brand">
         <div class="card-body">
-          <i class="tile-icon <%= icons.usuarios %>"></i>
+          <i class="tile-icon text-brand <%= icons.usuarios %>"></i>
           <p class="display-6"><%= counts.usuarios %></p>
           <p class="text-muted mb-0">Usuarios</p>
         </div>
       </div>
     </div>
     <div class="col-6 col-md-4 col-lg-2">
-      <div class="card text-center h-100">
+      <div class="card text-center h-100 summary-card border-danger">
         <div class="card-body">
-          <i class="tile-icon <%= icons.admins %>"></i>
+          <i class="tile-icon text-danger <%= icons.admins %>"></i>
           <p class="display-6"><%= counts.admins %></p>
           <p class="text-muted mb-0">Admins</p>
         </div>

--- a/src/views/pages/productos/list.ejs
+++ b/src/views/pages/productos/list.ejs
@@ -1,4 +1,5 @@
 <h1>Productos</h1>
+<div class="subheader mb-3"><span class="badge badge-brand">Listado</span></div>
 <a href="/productos/nuevo" class="btn btn-success mb-3">Nuevo</a>
 <button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
 <div id="searchBox" class="collapse"><!-- Siempre cerrado; se abre solo al pulsar "Buscar" -->
@@ -11,11 +12,12 @@
     </div>
   <% } %>
   <!-- Filtros de búsqueda. Envían GET a la ruta base y mantienen valores actuales -->
-  <form class="row g-3" method="get" action="<%= basePath %>">
+  <form class="row g-3" method="get" action="<%= basePath %>" data-search="productos">
     <div class="col-md-3">
       <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= query.qName || '' %>">
     </div>
     <div class="col-md-3">
+      <label class="form-label">Operador (Precio)</label>
       <div class="input-group">
         <select name="priceOp" class="form-select">
           <option value="">Operador</option>
@@ -23,11 +25,13 @@
           <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.priceOp==='gte'?'selected':'' %>>>=</option>
         </select>
+        <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" value="<%= query.price || '' %>">
       </div>
       <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
+      <label class="form-label">Operador (Stock)</label>
       <div class="input-group">
         <select name="stockOp" class="form-select">
           <option value="">Operador</option>
@@ -35,11 +39,13 @@
           <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.stockOp==='gte'?'selected':'' %>>>=</option>
         </select>
+        <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" name="stock" class="form-control" placeholder="Stock" value="<%= query.stock || '' %>">
       </div>
       <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
+      <label class="form-label">Operador (Stock mínimo)</label>
       <div class="input-group">
         <select name="minOp" class="form-select">
           <option value="">Operador</option>
@@ -47,6 +53,7 @@
           <option value="lte" <%= query.minOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.minOp==='gte'?'selected':'' %>>>=</option>
         </select>
+        <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" name="min" class="form-control" placeholder="Stock mín" value="<%= query.min || '' %>">
       </div>
       <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
@@ -86,8 +93,10 @@
         <option value="id" <%= (query.sortBy || 'id')==='id' ? 'selected' : '' %>>Ordenar por ID</option>
         <option value="nombre" <%= query.sortBy==='nombre'?'selected':'' %>>Nombre</option>
         <option value="precio" <%= query.sortBy==='precio'?'selected':'' %>>Precio</option>
+        <option value="costo" <%= query.sortBy==='costo'?'selected':'' %>>Costo</option>
         <option value="stock" <%= query.sortBy==='stock'?'selected':'' %>>Stock</option>
         <option value="stock_minimo" <%= query.sortBy==='stock_minimo'?'selected':'' %>>Stock mínimo</option>
+        <option value="localizacion" <%= query.sortBy==='localizacion'?'selected':'' %>>Localización</option>
       </select>
     </div>
     <div class="col-md-3">
@@ -147,7 +156,7 @@
     <% }) %>
   </tbody>
 </table>
-<% 
+<%
   const params = new URLSearchParams(query);
 %>
 <nav>


### PR DESCRIPTION
## Summary
- add SweetAlert hint and tooltips for search operators in products and low-stock
- allow sorting by cost/localization and refresh visual theme
- restore README with history and new changelog entry

## Testing
- `npm audit --omit=dev` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bf2cb6a404832aa7aee47659096dd4