### PR TITLE
feat: simplify operator UI and add themed views

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 3. En Bajo stock, repetir la prueba anterior.
 4. En cualquier listado, ordenar por Costo y comprobar el orden.
 5. Revisar navbar y subheaders en distintas vistas; títulos dinámicos.
+6. Fondos por vista: panel, productos y bajo stock muestran colores suaves distintos.
+7. Formularios de búsqueda: etiquetas "Precio", "Stock" y "Stock mín." sin textos de ayuda redundantes; el popup aparece si falta operador.
+8. Detalle de producto muestra badge "Bajo stock" si el stock es menor al mínimo.
+9. Badges de categoría/proveedor/localización conservan color consistente en listas y detalle.
+10. Paginación no abre automáticamente el panel de búsqueda.
 
 ## Troubleshooting
 - **DB access denied**: revisa credenciales y privilegios MySQL.
@@ -174,6 +179,12 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 - **Errores al importar seeds**: asegúrate de que la base existe y de tener permisos.
 
 ## CHANGELOG
+## [2025-09-08 22:26] – UX operadores, fondos por vista, badge detalle, colores taxonomías, limpieza subtítulos
+- Limpieza de textos de ayuda y palabra "Operador" en filtros de Productos y Bajo stock; etiquetas unificadas.
+- Eliminación de subtítulos redundantes en Panel, Productos y Bajo stock.
+- Nuevos fondos por vista mediante variables CSS.
+- Badge reutilizable de "Bajo stock" y colores determinísticos por categoría/proveedor/localización.
+- README ampliado con pruebas manuales actualizadas.
 ## [2025-09-08 19:25] – Popup de operadores, ordenar por costo, estilo visual y README restaurado
 - Añadido popup (SweetAlert2) y tooltip para operadores en productos y bajo stock; backend mantiene '=' por defecto si no se elige operador.
 - “Ordenar por…” ampliado con Costo y campos pendientes; validación/whitelist en controladores/validators.

--- a/src/controllers/bajo-stock.controller.js
+++ b/src/controllers/bajo-stock.controller.js
@@ -56,7 +56,7 @@ exports.list = async (req, res) => {
   const baseSql = `FROM productos p LEFT JOIN localizaciones l ON p.localizacion_id = l.id ${joinSql} ${whereSql}`;
 
   const [rows] = await pool.query(
-    `SELECT DISTINCT p.*, l.nombre AS localizacion ${baseSql} ORDER BY ${sortCol} ${sortDirSql} LIMIT ? OFFSET ?`,
+    `SELECT DISTINCT p.*, l.id AS localizacion_id, l.nombre AS localizacion ${baseSql} ORDER BY ${sortCol} ${sortDirSql} LIMIT ? OFFSET ?`,
     [...params, limit, offset]
   );
 
@@ -81,6 +81,7 @@ exports.list = async (req, res) => {
     categorias,
     proveedores,
     query: req.query,
-    errors: errors.array()
+    errors: errors.array(),
+    viewClass: 'view-bajo-stock' // Clase de fondo para la vista
   });
 };

--- a/src/controllers/panel.controller.js
+++ b/src/controllers/panel.controller.js
@@ -33,5 +33,11 @@ exports.index = async (req, res) => {
     counts.admins = adm[0].n;
   }
 
-  res.render('pages/panel', { title: 'Panel de inventario', counts, icons, isAdmin });
+  res.render('pages/panel', {
+    title: 'Panel de inventario',
+    counts,
+    icons,
+    isAdmin,
+    viewClass: 'view-panel' // Clase de fondo para la vista
+  });
 };

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -58,3 +58,53 @@ body {
 .badge-accent{background-color:var(--accent);}
 .badge-warning{background-color:var(--warning);}
 .badge-brand,.badge-accent,.badge-warning{color:#fff;}
+
+/* Fondos personalizados por vista */
+:root {
+  --view-panel-bg: #eef6ff;
+  --view-productos-bg: #f1fff6;
+  --view-bajo-stock-bg: #fff7f5;
+  --view-usuarios-bg: #f6f5ff;
+  --view-categorias-bg: #fffdf2;
+  --view-proveedores-bg: #f5fffe;
+  --view-localizaciones-bg: #f8fbff;
+}
+.view-panel{background:var(--view-panel-bg);}
+.view-productos{background:var(--view-productos-bg);}
+.view-bajo-stock{background:var(--view-bajo-stock-bg);}
+.view-usuarios{background:var(--view-usuarios-bg);}
+.view-categorias{background:var(--view-categorias-bg);}
+.view-proveedores{background:var(--view-proveedores-bg);}
+.view-localizaciones{background:var(--view-localizaciones-bg);}
+
+/* Badge "Bajo stock" consistente */
+.badge-bajo-stock{
+  background:#ffe2e1;
+  color:#b42318;
+  border:1px solid #ffcbc7;
+  font-weight:600;
+}
+
+/* Sistema de colores por taxonomía (12 buckets) */
+.tag-bucket-0{background:#e3f2fd;color:#0b4f8a;border-color:#cde6fb;}
+.tag-bucket-1{background:#e8f5e9;color:#1b5e20;border-color:#d4edd6;}
+.tag-bucket-2{background:#fff3e0;color:#e65100;border-color:#ffe2bd;}
+.tag-bucket-3{background:#fce4ec;color:#880e4f;border-color:#f7c7da;}
+.tag-bucket-4{background:#ede7f6;color:#4527a0;border-color:#dccff2;}
+.tag-bucket-5{background:#e0f7fa;color:#006064;border-color:#caf2f6;}
+.tag-bucket-6{background:#f9fbe7;color:#827717;border-color:#eef3c4;}
+.tag-bucket-7{background:#efebe9;color:#4e342e;border-color:#e3d6d0;}
+.tag-bucket-8{background:#f3e5f5;color:#6a1b9a;border-color:#e7cdf0;}
+.tag-bucket-9{background:#e1f5fe;color:#01579b;border-color:#cbeefe;}
+.tag-bucket-10{background:#fbe9e7;color:#bf360c;border-color:#f7d2cb;}
+.tag-bucket-11{background:#fffde7;color:#f57f17;border-color:#fff7b3;}
+
+.tag{
+  display:inline-block;
+  padding:.25rem .5rem;
+  border:1px solid transparent;
+  border-radius:.5rem;
+  font-size:.85rem;
+  line-height:1;
+  font-weight:600;
+}

--- a/src/views/layouts/layout.ejs
+++ b/src/views/layouts/layout.ejs
@@ -10,7 +10,7 @@
   </head>
   <body>
     <%- include('../partials/header') %>
-    <main class="container mt-4">
+    <main class="container mt-4 <%= viewClass || '' %>">
       <%- body %>
     </main>
     <%- include('../partials/footer') %>

--- a/src/views/pages/bajo-stock.ejs
+++ b/src/views/pages/bajo-stock.ejs
@@ -1,5 +1,4 @@
 <h1>Bajo stock</h1>
-<div class="subheader mb-3"><span class="badge badge-warning">Listado</span></div>
 <button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
 <div id="searchBox" class="collapse"><!-- Collapse cerrado por defecto -->
   <% if (errors && errors.length) { %>
@@ -15,10 +14,10 @@
       <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= query.qName || '' %>">
     </div>
     <div class="col-md-3">
-      <label class="form-label">Operador (Precio)</label>
+      <label class="form-label">Precio</label>
       <div class="input-group">
         <select name="priceOp" class="form-select">
-          <option value="">Operador</option>
+          <option value=""></option>
           <option value="eq" <%= query.priceOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.priceOp==='gte'?'selected':'' %>>>=</option>
@@ -26,13 +25,12 @@
         <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" value="<%= query.price || '' %>">
       </div>
-      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
-      <label class="form-label">Operador (Stock)</label>
+      <label class="form-label">Stock</label>
       <div class="input-group">
         <select name="stockOp" class="form-select">
-          <option value="">Operador</option>
+          <option value=""></option>
           <option value="eq" <%= query.stockOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.stockOp==='gte'?'selected':'' %>>>=</option>
@@ -40,13 +38,12 @@
         <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" name="stock" class="form-control" placeholder="Stock" value="<%= query.stock || '' %>">
       </div>
-      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
-      <label class="form-label">Operador (Stock mínimo)</label>
+      <label class="form-label">Stock mín.</label>
       <div class="input-group">
         <select name="minOp" class="form-select">
-          <option value="">Operador</option>
+          <option value=""></option>
           <option value="eq" <%= query.minOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.minOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.minOp==='gte'?'selected':'' %>>>=</option>
@@ -54,7 +51,6 @@
         <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" name="min" class="form-control" placeholder="Stock mín" value="<%= query.min || '' %>">
       </div>
-      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
       <select name="localizacionId" class="form-select">
@@ -137,7 +133,11 @@
             <i class='bx bx-info-circle' data-bs-toggle="tooltip" title="<%= p.observaciones %>"></i>
           <% } %>
         </td>
-        <td><%= p.localizacion %></td>
+        <td>
+          <% if (p.localizacion) { const bucket = p.localizacion_id % 12; %>
+            <span class="tag tag-bucket-<%= bucket %>"><%= p.localizacion %></span>
+          <% } %>
+        </td>
         <td>
           <a href="/productos/<%= p.id %>?returnTo=<%= encodeURIComponent(request.originalUrl) %>" class="btn btn-sm btn-primary"><i class='bx bx-show'></i></a>
         </td>

--- a/src/views/pages/panel.ejs
+++ b/src/views/pages/panel.ejs
@@ -1,5 +1,4 @@
 <h1 class="mb-4">Resumen</h1>
-<div class="subheader mb-3"><span class="badge badge-accent">Panel</span></div>
 <div class="row g-3">
   <div class="col-6 col-md-4 col-lg-2">
     <div class="card text-center h-100 summary-card border-brand">

--- a/src/views/pages/productos/detail.ejs
+++ b/src/views/pages/productos/detail.ejs
@@ -1,10 +1,28 @@
+<% if (isBajoStock) { %>
+  <span class="badge badge-bajo-stock">Bajo stock</span>
+<% } %>
 <h1><%= producto.nombre %></h1>
 <p><strong>Descripción:</strong> <%= producto.descripcion %></p>
 <p><strong>Costo:</strong> <%= producto.costo %></p>
 <p><strong>Precio:</strong> <%= producto.precio %></p>
 <p><strong>Stock:</strong> <%= producto.stock %> / <%= producto.stock_minimo %></p>
-<p><strong>Localización:</strong> <%= producto.localizacion %></p>
-<p><strong>Categorías:</strong> <%= producto.categorias.map(c=>c.nombre).join(', ') %></p>
-<p><strong>Proveedores:</strong> <%= producto.proveedores.map(p=>p.nombre).join(', ') %></p>
+<p><strong>Localización:</strong>
+  <% if (producto.localizacion) { const bucket = producto.localizacion_id % 12; %>
+    <span class="tag tag-bucket-<%= bucket %>"><%= producto.localizacion %></span>
+  <% } else { %>-
+  <% } %>
+</p>
+<p><strong>Categorías:</strong>
+  <% if (producto.categorias.length) { producto.categorias.forEach(c => { const bucket = c.id % 12; %>
+    <span class="tag tag-bucket-<%= bucket %>"><%= c.nombre %></span>
+  <% }) } else { %>-
+  <% } %>
+</p>
+<p><strong>Proveedores:</strong>
+  <% if (producto.proveedores.length) { producto.proveedores.forEach(pv => { const bucket = pv.id % 12; %>
+    <span class="tag tag-bucket-<%= bucket %>"><%= pv.nombre %></span>
+  <% }) } else { %>-
+  <% } %>
+</p>
 <p><strong>Observaciones:</strong> <%= producto.observaciones %></p>
 <a href="<%= returnTo || '/productos' %>" class="btn btn-secondary">Volver</a>

--- a/src/views/pages/productos/list.ejs
+++ b/src/views/pages/productos/list.ejs
@@ -1,5 +1,4 @@
 <h1>Productos</h1>
-<div class="subheader mb-3"><span class="badge badge-brand">Listado</span></div>
 <a href="/productos/nuevo" class="btn btn-success mb-3">Nuevo</a>
 <button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
 <div id="searchBox" class="collapse"><!-- Siempre cerrado; se abre solo al pulsar "Buscar" -->
@@ -17,10 +16,10 @@
       <input type="text" name="qName" class="form-control" placeholder="Nombre" value="<%= query.qName || '' %>">
     </div>
     <div class="col-md-3">
-      <label class="form-label">Operador (Precio)</label>
+      <label class="form-label">Precio</label>
       <div class="input-group">
         <select name="priceOp" class="form-select">
-          <option value="">Operador</option>
+          <option value=""></option>
           <option value="eq" <%= query.priceOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.priceOp==='gte'?'selected':'' %>>>=</option>
@@ -28,13 +27,12 @@
         <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" step="0.01" name="price" class="form-control" placeholder="Precio" value="<%= query.price || '' %>">
       </div>
-      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
-      <label class="form-label">Operador (Stock)</label>
+      <label class="form-label">Stock</label>
       <div class="input-group">
         <select name="stockOp" class="form-select">
-          <option value="">Operador</option>
+          <option value=""></option>
           <option value="eq" <%= query.stockOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.stockOp==='gte'?'selected':'' %>>>=</option>
@@ -42,13 +40,12 @@
         <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" name="stock" class="form-control" placeholder="Stock" value="<%= query.stock || '' %>">
       </div>
-      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
-      <label class="form-label">Operador (Stock mínimo)</label>
+      <label class="form-label">Stock mín.</label>
       <div class="input-group">
         <select name="minOp" class="form-select">
-          <option value="">Operador</option>
+          <option value=""></option>
           <option value="eq" <%= query.minOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.minOp==='lte'?'selected':'' %>><=</option>
           <option value="gte" <%= query.minOp==='gte'?'selected':'' %>>>=</option>
@@ -56,7 +53,6 @@
         <span class="input-group-text"><i class='bx bx-info-circle' data-bs-toggle="tooltip" title="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto."></i></span>
         <input type="number" name="min" class="form-control" placeholder="Stock mín" value="<%= query.min || '' %>">
       </div>
-      <div class="form-text">Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.</div>
     </div>
     <div class="col-md-3">
       <select name="localizacionId" class="form-select">
@@ -134,7 +130,7 @@
         <td><%= p.nombre %></td>
         <td><%= p.precio %></td>
         <td><%= p.costo %></td>
-        <td><%= p.stock %> <% if (p.stock < p.stock_minimo) { %><span class="badge bg-danger">Bajo stock</span><% } %></td>
+        <td><%= p.stock %> <% if (p.stock < p.stock_minimo) { %><span class="badge badge-bajo-stock">Bajo stock</span><% } %></td>
         <td><%= p.stock_minimo %></td>
         <td>
           <% if (p.descripcion) { %>
@@ -146,7 +142,11 @@
             <i class='bx bx-info-circle' data-bs-toggle="tooltip" title="<%= p.observaciones %>"></i>
           <% } %>
         </td>
-        <td><%= p.localizacion %></td>
+        <td>
+          <% if (p.localizacion) { const bucket = p.localizacion_id % 12; %>
+            <span class="tag tag-bucket-<%= bucket %>"><%= p.localizacion %></span>
+          <% } %>
+        </td>
         <td>
           <a href="/productos/<%= p.id %>?returnTo=<%= encodeURIComponent(request.originalUrl) %>" class="btn btn-sm btn-primary"><i class='bx bx-show'></i></a>
           <a href="/productos/<%= p.id %>/editar" class="btn btn-sm btn-warning"><i class='bx bx-edit'></i></a>


### PR DESCRIPTION
## Summary
- Cleaned search filters by dropping operator labels and help text
- Added per-view background classes and consistent low-stock badge
- Introduced color buckets for categories, providers and locations

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf578f0d34832a8ebfb05bad20019b