### PR TITLE
feat: add shape legend and improve product detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 - **Errores al importar seeds**: asegúrate de que la base existe y de tener permisos.
 
 ## CHANGELOG
+## [2025-09-09 03:40] – Detalle con símbolos, triángulo en localización, alineado/espaciado, popover de operadores al pasar y leyenda
+- Detalle de producto con todos los datos y símbolos junto a cada dato; badge Bajo stock conservado.
+- Localizaciones representadas con triángulos coherentes en todas las vistas.
+- Alineado/espaciado mejorado para evitar solapes de iconos y descentrados.
+- Popover de ayuda en operadores (hover) en paneles de búsqueda.
+- Leyenda reutilizable (círculo=Categoría, cuadrado=Proveedor, triángulo=Localización) incluida en vistas necesarias.
+- Limpieza de código y comentarios añadidos.
 ## [2025-09-09 02:30] – Popup operadores + orden invertido + formas y colores vivos + iconos a la derecha + panel clicable
 - Se restaura el popup de ayuda en operadores (=, ≤, ≥) para precio/stock/stock mín.; backend sigue usando '=' por defecto si no se elige.
 - Se invierte el orden de campos: operador a la izquierda, número a la derecha; placeholders claros ('Precio/Stock/Stock mín.' y 'num').

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -60,17 +60,14 @@ body {
   font-weight:600;
 }
 
-/* shapes (circle/square/triangle), buckets vivos, filas coloreadas, layout flex del nombre */
-.shape{display:inline-block;width:.8rem;height:.8rem;margin-left:.35rem;vertical-align:middle;}
+/* shapes (circle/square/triangle) y layout del nombre */
+.product-name-row{display:flex;justify-content:space-between;align-items:center;gap:.5rem;}
+.shape-stack{display:flex;flex-direction:column;align-items:flex-end;gap:.15rem;}
+.shape-row{display:flex;gap:.35rem;flex-wrap:wrap;justify-content:flex-end;}
+.shape{display:inline-block;width:.85rem;height:.85rem;margin-left:.35rem;vertical-align:middle;box-shadow:0 0 0 1px rgba(0,0,0,.15);}
 .shape-circle{border-radius:50%;}
 .shape-square{border-radius:.15rem;}
-.shape-triangle{
-  width:0;height:0;
-  border-left:.45rem solid transparent;
-  border-right:.45rem solid transparent;
-  border-bottom:.8rem solid currentColor;
-  margin-left:.35rem;
-}
+.shape-triangle{width:0;height:0;border-left:.45rem solid transparent;border-right:.45rem solid transparent;border-bottom:.85rem solid currentColor;margin-left:.35rem;filter:drop-shadow(0 0 1px rgba(0,0,0,.15));}
 /* mapeo buckets vivos (colores accesibles) */
 .shape-bucket-0{background:#3b82f6;color:#3b82f6;border:1px solid #1d4ed8;}
 .shape-bucket-1{background:#10b981;color:#10b981;border:1px solid #047857;}
@@ -97,7 +94,6 @@ body {
 .row-bucket-9  > td{background:#e6f6ff;}
 .row-bucket-10 > td{background:#eafff0;}
 .row-bucket-11 > td{background:#f5e9ff;}
-/* Layout para nombre + shapes alineadas a la derecha */
-.name-cell{display:flex;justify-content:space-between;align-items:center;}
-.shape-group{display:flex;flex-direction:column;align-items:flex-end;}
-.shape-row{display:flex;gap:.25rem;flex-wrap:wrap;}
+/* Leyenda compacta (círculo=Categoría, cuadrado=Proveedor, triángulo=Localización) */
+.legend-shapes{display:flex;align-items:center;gap:.5rem;font-size:.875rem;}
+.legend-shapes .shape{margin-left:0;}

--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -1,12 +1,14 @@
 // Lógica global del frontend
 
-/* Inicialización global de tooltips y popovers.
-   Propósito: activar ayudas visuales de Bootstrap.
-   Entradas: elementos con data-bs-toggle="tooltip" o "popover".
+/* Inicialización de tooltips y popovers.
+   Propósito: mostrar ayudas en formas y operadores.
+   Entradas: elementos con data-bs-toggle="tooltip" y selects priceOp|stockOp|minOp.
    Salidas: tooltips/popovers visibles.
    Dependencias: Bootstrap 5. */
 document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
-document.querySelectorAll('[data-bs-toggle="popover"]').forEach(el => new bootstrap.Popover(el, { trigger: 'hover', html: true }));
+document.querySelectorAll('select[name="priceOp"],select[name="stockOp"],select[name="minOp"]').forEach(el =>
+  new bootstrap.Popover(el, { trigger: 'hover focus' })
+);
 
 /* Popup informativo para operadores numéricos.
    Propósito: avisar cuando se ingresa un número sin operador.

--- a/src/views/pages/bajo-stock.ejs
+++ b/src/views/pages/bajo-stock.ejs
@@ -15,7 +15,7 @@
     </div>
     <div class="col-md-3">
       <div class="d-flex gap-2">
-        <select name="priceOp" class="form-select">
+        <select name="priceOp" class="form-select" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.">
           <option value="">Precio</option>
           <option value="eq" <%= query.priceOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>>&le;</option>
@@ -26,7 +26,7 @@
     </div>
     <div class="col-md-3">
       <div class="d-flex gap-2">
-        <select name="stockOp" class="form-select">
+        <select name="stockOp" class="form-select" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.">
           <option value="">Stock</option>
           <option value="eq" <%= query.stockOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>>&le;</option>
@@ -37,7 +37,7 @@
     </div>
     <div class="col-md-3">
       <div class="d-flex gap-2">
-        <select name="minOp" class="form-select">
+        <select name="minOp" class="form-select" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.">
           <option value="">Stock mín.</option>
           <option value="eq" <%= query.minOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.minOp==='lte'?'selected':'' %>>&le;</option>
@@ -93,6 +93,7 @@
     </div>
   </form>
 </div>
+<%- include('../partials/legend-shapes') %><!-- Leyenda de formas -->
 <table class="table table-striped">
   <thead>
     <tr>
@@ -112,23 +113,33 @@
     <% productos.forEach(p => { %>
       <tr class="table-warning">
         <td><%= p.id %></td>
-        <td class="name-cell">
-          <span><%= p.nombre %></span>
-          <div class="shape-group">
-            <% if (p.categorias.length) { %>
-              <div class="shape-row">
-                <% p.categorias.forEach(c => { const bucket = c.id % 12; %>
-                  <span class="shape shape-circle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Categoría: <%= c.nombre %>"></span>
-                <% }) %>
-              </div>
-            <% } %>
-            <% if (p.proveedores.length) { %>
-              <div class="shape-row">
-                <% p.proveedores.forEach(pr => { const bucket = pr.id % 12; %>
-                  <span class="shape shape-square shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Proveedor: <%= pr.nombre %>"></span>
-                <% }) %>
-              </div>
-            <% } %>
+        <td>
+          <!-- Nombre y símbolos: categorías (círculos), proveedores (cuadrados) y localización (triángulo) -->
+          <div class="product-name-row">
+            <div class="product-name-text"><%= p.nombre %></div>
+            <div class="d-flex align-items-center">
+              <% if (p.categorias.length || p.proveedores.length) { %>
+                <div class="shape-stack">
+                  <% if (p.categorias.length) { %>
+                    <div class="shape-row">
+                      <% p.categorias.forEach(c => { const bucket = c.id % 12; %>
+                        <span class="shape shape-circle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Categoría: <%= c.nombre %>"></span>
+                      <% }) %>
+                    </div>
+                  <% } %>
+                  <% if (p.proveedores.length) { %>
+                    <div class="shape-row">
+                      <% p.proveedores.forEach(pr => { const bucket = pr.id % 12; %>
+                        <span class="shape shape-square shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Proveedor: <%= pr.nombre %>"></span>
+                      <% }) %>
+                    </div>
+                  <% } %>
+                </div>
+              <% } %>
+              <% if (p.localizacion) { const bucket = p.localizacion_id % 12; %>
+                <span class="shape shape-triangle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Localización: <%= p.localizacion %>"></span>
+              <% } %>
+            </div>
           </div>
         </td>
         <td><%= p.precio %></td>

--- a/src/views/pages/productos/detail.ejs
+++ b/src/views/pages/productos/detail.ejs
@@ -1,34 +1,62 @@
-<div class="name-cell mb-2">
-  <div class="d-flex align-items-center">
+<!-- Detalle de producto con shapes por taxonomía -->
+<div class="product-name-row mb-3">
+  <div class="product-name-text d-flex align-items-center gap-2">
     <h1 class="mb-0"><%= producto.nombre %></h1>
-    <% if (isBajoStock) { %><span class="badge badge-bajo-stock ms-2">Bajo stock</span><% } %>
+    <% if (isBajoStock) { %><span class="badge badge-bajo-stock">Bajo stock</span><% } %>
   </div>
-  <div class="shape-group">
-    <% if (producto.categorias.length) { %>
-      <div class="shape-row">
-        <% producto.categorias.forEach(c => { const bucket = c.id % 12; %>
-          <span class="shape shape-circle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Categoría: <%= c.nombre %>"></span>
-        <% }) %>
+  <div class="d-flex align-items-center">
+    <% if (producto.categorias.length || producto.proveedores.length) { %>
+      <div class="shape-stack">
+        <% if (producto.categorias.length) { %>
+          <div class="shape-row">
+            <% producto.categorias.forEach(c => { const bucket = c.id % 12; %>
+              <span class="shape shape-circle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Categoría: <%= c.nombre %>"></span>
+            <% }) %>
+          </div>
+        <% } %>
+        <% if (producto.proveedores.length) { %>
+          <div class="shape-row">
+            <% producto.proveedores.forEach(pv => { const bucket = pv.id % 12; %>
+              <span class="shape shape-square shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Proveedor: <%= pv.nombre %>"></span>
+            <% }) %>
+          </div>
+        <% } %>
       </div>
     <% } %>
-    <% if (producto.proveedores.length) { %>
-      <div class="shape-row">
-        <% producto.proveedores.forEach(pv => { const bucket = pv.id % 12; %>
-          <span class="shape shape-square shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Proveedor: <%= pv.nombre %>"></span>
-        <% }) %>
-      </div>
+    <% if (producto.localizacion) { const bucket = producto.localizacion_id % 12; %>
+      <span class="shape shape-triangle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Localización: <%= producto.localizacion %>"></span>
     <% } %>
   </div>
 </div>
-<p><strong>Descripción:</strong> <%= producto.descripcion %></p>
-<p><strong>Costo:</strong> <%= producto.costo %></p>
+<p><strong>Descripción:</strong> <%= producto.descripcion || '-' %></p>
 <p><strong>Precio:</strong> <%= producto.precio %></p>
-<p><strong>Stock:</strong> <%= producto.stock %> / <%= producto.stock_minimo %></p>
+<p><strong>Costo:</strong> <%= producto.costo %></p>
+<p><strong>Stock:</strong> <%= producto.stock %></p>
+<p><strong>Stock mín.:</strong> <%= producto.stock_minimo %></p>
+<p><strong>Categorías:</strong>
+  <% if (producto.categorias.length) { %>
+    <% producto.categorias.forEach((c,i) => { const bucket = c.id % 12; %>
+      <span class="shape shape-circle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Categoría: <%= c.nombre %>"></span>
+      <%= c.nombre %><%= i < producto.categorias.length - 1 ? ', ' : '' %>
+    <% }) %>
+  <% } else { %>-<% } %>
+</p>
+<p><strong>Proveedores:</strong>
+  <% if (producto.proveedores.length) { %>
+    <% producto.proveedores.forEach((pr,i) => { const bucket = pr.id % 12; %>
+      <span class="shape shape-square shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Proveedor: <%= pr.nombre %>"></span>
+      <%= pr.nombre %><%= i < producto.proveedores.length - 1 ? ', ' : '' %>
+    <% }) %>
+  <% } else { %>-<% } %>
+</p>
 <p><strong>Localización:</strong>
   <% if (producto.localizacion) { const bucket = producto.localizacion_id % 12; %>
     <span class="shape shape-triangle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Localización: <%= producto.localizacion %>"></span>
     <%= producto.localizacion %>
   <% } else { %>-<% } %>
 </p>
-<p><strong>Observaciones:</strong> <%= producto.observaciones %></p>
+<% if (producto.observaciones) { %>
+  <p><strong>Observaciones:</strong> <%= producto.observaciones %></p>
+<% } %>
+<%- include('../../partials/legend-shapes') %><!-- Leyenda de formas -->
 <a href="<%= returnTo || '/productos' %>" class="btn btn-secondary">Volver</a>

--- a/src/views/pages/productos/list.ejs
+++ b/src/views/pages/productos/list.ejs
@@ -17,7 +17,7 @@
     </div>
     <div class="col-md-3">
       <div class="d-flex gap-2">
-        <select name="priceOp" class="form-select">
+        <select name="priceOp" class="form-select" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.">
           <option value="">Precio</option>
           <option value="eq" <%= query.priceOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.priceOp==='lte'?'selected':'' %>>&le;</option>
@@ -28,7 +28,7 @@
     </div>
     <div class="col-md-3">
       <div class="d-flex gap-2">
-        <select name="stockOp" class="form-select">
+        <select name="stockOp" class="form-select" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.">
           <option value="">Stock</option>
           <option value="eq" <%= query.stockOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.stockOp==='lte'?'selected':'' %>>&le;</option>
@@ -39,7 +39,7 @@
     </div>
     <div class="col-md-3">
       <div class="d-flex gap-2">
-        <select name="minOp" class="form-select">
+        <select name="minOp" class="form-select" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Selecciona operador (=, ≤, ≥). Si no eliges ninguno, se usa '=' por defecto.">
           <option value="">Stock mín.</option>
           <option value="eq" <%= query.minOp==='eq'?'selected':'' %>>=</option>
           <option value="lte" <%= query.minOp==='lte'?'selected':'' %>>&le;</option>
@@ -102,6 +102,7 @@
     </div>
   </form>
 </div>
+<%- include('../../partials/legend-shapes') %><!-- Leyenda de formas -->
 <table class="table table-striped">
   <thead>
     <tr>
@@ -121,23 +122,33 @@
     <% productos.forEach(p => { %>
       <tr class="<%= p.stock < p.stock_minimo ? 'table-warning' : '' %>">
         <td><%= p.id %></td>
-        <td class="name-cell">
-          <span><%= p.nombre %></span>
-          <div class="shape-group">
-            <% if (p.categorias.length) { %>
-              <div class="shape-row">
-                <% p.categorias.forEach(c => { const bucket = c.id % 12; %>
-                  <span class="shape shape-circle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Categoría: <%= c.nombre %>"></span>
-                <% }) %>
-              </div>
-            <% } %>
-            <% if (p.proveedores.length) { %>
-              <div class="shape-row">
-                <% p.proveedores.forEach(pr => { const bucket = pr.id % 12; %>
-                  <span class="shape shape-square shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Proveedor: <%= pr.nombre %>"></span>
-                <% }) %>
-              </div>
-            <% } %>
+        <td>
+          <!-- Nombre y símbolos: categorías (círculos), proveedores (cuadrados) y localización (triángulo) -->
+          <div class="product-name-row">
+            <div class="product-name-text"><%= p.nombre %></div>
+            <div class="d-flex align-items-center">
+              <% if (p.categorias.length || p.proveedores.length) { %>
+                <div class="shape-stack">
+                  <% if (p.categorias.length) { %>
+                    <div class="shape-row">
+                      <% p.categorias.forEach(c => { const bucket = c.id % 12; %>
+                        <span class="shape shape-circle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Categoría: <%= c.nombre %>"></span>
+                      <% }) %>
+                    </div>
+                  <% } %>
+                  <% if (p.proveedores.length) { %>
+                    <div class="shape-row">
+                      <% p.proveedores.forEach(pr => { const bucket = pr.id % 12; %>
+                        <span class="shape shape-square shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Proveedor: <%= pr.nombre %>"></span>
+                      <% }) %>
+                    </div>
+                  <% } %>
+                </div>
+              <% } %>
+              <% if (p.localizacion) { const bucket = p.localizacion_id % 12; %>
+                <span class="shape shape-triangle shape-bucket-<%= bucket %>" data-bs-toggle="tooltip" title="Localización: <%= p.localizacion %>"></span>
+              <% } %>
+            </div>
           </div>
         </td>
         <td><%= p.precio %></td>

--- a/src/views/partials/legend-shapes.ejs
+++ b/src/views/partials/legend-shapes.ejs
@@ -1,0 +1,6 @@
+<!-- Leyenda compacta: círculo=Categoría, cuadrado=Proveedor, triángulo=Localización -->
+<div class="legend-shapes mt-2">
+  <span><span class="shape shape-circle shape-bucket-0"></span> Categoría</span>
+  <span><span class="shape shape-square shape-bucket-1"></span> Proveedor</span>
+  <span><span class="shape shape-triangle shape-bucket-2"></span> Localización</span>
+</div>


### PR DESCRIPTION
## Summary
- add reusable legend for category, provider, and location shapes
- show full product detail with colored shapes and low stock badge
- enhance product and low stock lists with popovers and aligned icons

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf8550afcc832a9329d17fe4b3f9b3