### PR TITLE
Improve navbar spacing and stock indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
   - Sustituir imagen con .png → se actualiza y elimina la extensión anterior.
 - En login, el botón ver/ocultar alterna correctamente y cambia icono/aria.
 - Navegación returnTo sigue funcionando tras crear/editar/eliminar.
+
+### Pruebas manuales de UI
+- Navbar con espacio superior y enlace activo resaltado.
+- Panel: todas las tarjetas mismos tamaños, iconos a ~1.75rem, colores Bootstrap.
+- Productos: badge rojo ‘Bajo stock’ junto a stock cuando stock <= stock_minimo.
+- Bajo stock: sin botón ‘Volver’; listado correcto.
+- Proveedores: icono tamaño normal (no gigante).
+
 ## Troubleshooting
 - **DB access denied**: revisa credenciales y privilegios MySQL.
 - **Módulos EJS/layouts no encontrados**: ejecuta `npm install`.
@@ -226,6 +234,12 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 - **Errores al importar seeds**: asegúrate de que la base existe y de tener permisos.
 
 ## CHANGELOG
+## [2025-09-10 20:00] – Ajustes de UI
+- Restaurado espaciado de navbar y estado activo en navegación.
+- Tarjetas del panel uniformes con colores consistentes e iconos a tamaño correcto.
+- Reinstaurado badge rojo ‘Bajo stock’ junto a Stock en listas y detalle.
+- Eliminado botón ‘Volver’ en vista Bajo stock.
+
 ## [2025-09-10 19:30] – Imágenes y redirecciones seguras
 - Corregida ruta de imágenes de producto para que se muestren desde `/resources/uploads/products`.
 - Validación de returnTo para evitar redirecciones externas.

--- a/src/controllers/productos.controller.js
+++ b/src/controllers/productos.controller.js
@@ -347,7 +347,6 @@ exports.bajoStock = async (req, res) => {
     proveedores,
     query: req.query,
     errors: errors.array(),
-    returnTo: req.query.returnTo, // Para botón Volver
     viewClass: 'view-bajo-stock'
   });
 };

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1,75 +1,66 @@
-/* Variables de tema y colores principales */
-:root {
-  --brand:#2563eb; --accent:#10b981; --muted:#64748b;
-  --success:#22c55e; --warning:#f59e0b; --danger:#ef4444;
-  --card-bg:#ffffff; --card-border:#e5e7eb; --page-bg:#f8fafc;
+/* Escala y variables base */
+:root{
+  /* Paleta base (puedes ajustar si el proyecto tenía otra) */
+  --space-1: .5rem;
+  --space-2: 1rem;
+  --space-3: 1.5rem;
+  --radius-lg: 1rem;
+  --shadow-1: 0 2px 10px rgba(0,0,0,.06);
+  --brand-active-bg: #e7f1ff; /* azul muy suave para activo */
+  --brand-active-border: #b6d3ff;
+  --danger-strong: #dc3545;  /* Bootstrap danger */
 }
 
-/* Ajustes generales */
-body {
-  padding-top:60px;
-  background-color: var(--page-bg);
+/* Espacio bajo navbar para que no “pegue” al borde superior */
+.navbar-spacer{ height: var(--space-2); }
+
+/* Estado activo del enlace de navegación */
+.navbar .nav-link.active{
+  background: var(--brand-active-bg);
+  border: 1px solid var(--brand-active-border);
+  border-radius: var(--radius-lg);
 }
 
-/* Navbar con enlaces activos y separación sutil */
-.navbar-identity {
-  color:#fff;
-  padding:.5rem 1rem;
-  background-color:rgba(255,255,255,0.1);
-  border-radius:.25rem;
+/* Tarjetas de resumen del panel */
+.card-summary{
+  min-height: 140px;             /* uniformidad */
+  border: none;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-1);
 }
-.nav-link.active {
-  font-weight:500;
-  border-bottom:2px solid var(--brand);
-  border-radius:.25rem;
-  color:var(--brand)!important;
+.card-summary .summary-icon{
+  font-size: 1.75rem;            /* iconos consistentes */
+  opacity: .9;
 }
-.nav-link:hover { color:var(--brand); }
-.nav-separated .nav-link + .nav-link { border-left:1px solid rgba(0,0,0,.1); }
-
-/* Tarjetas del panel/resumen */
-.summary-card {
-  background:var(--card-bg);
-  border:1px solid var(--card-border);
-  box-shadow:0 .125rem .25rem rgba(0,0,0,.05);
-  border-left:4px solid transparent;
-}
-.border-brand{border-left-color:var(--brand)!important;}
-.border-accent{border-left-color:var(--accent)!important;}
-.border-muted{border-left-color:var(--muted)!important;}
-.border-success{border-left-color:var(--success)!important;}
-.border-warning{border-left-color:var(--warning)!important;}
-.border-danger{border-left-color:var(--danger)!important;}
-.tile-icon{
-  font-size:1.75rem;
-  width:1.75rem;
-  height:1.75rem;
-}
-.text-brand{color:var(--brand)!important;}
-.text-accent{color:var(--accent)!important;}
-.text-muted{color:var(--muted)!important;}
-.text-success{color:var(--success)!important;}
-.text-warning{color:var(--warning)!important;}
-.text-danger{color:var(--danger)!important;}
-
-/* Badge "Bajo stock" consistente */
-.badge-bajo-stock{
-  background:#ffe2e1;
-  color:#b42318;
-  border:1px solid #ffcbc7;
-  font-weight:600;
+.card-summary .summary-value{
+  font-size: 1.8rem;
+  font-weight: 700;
+  line-height: 1;
 }
 
-/* Columna Procedencia: alinea el botón/ícono al centro */
-.procedencia-cell{text-align:center;}
+/* Iconos embebidos en tablas (categorías, proveedores, etc.) */
+.icon-inline{
+  font-size: 1rem;
+  vertical-align: middle;
+}
 
-/* Grids multicolumna de checkboxes (categorías/proveedores)
-   Ajusta las clases row-cols-* en la vista para cambiar columnas */
+/* Badge de bajo stock coherente y legible */
+.badge-lowstock{
+  background: var(--danger-strong);
+  color: #fff;
+  border-radius: .5rem;
+  font-weight: 600;
+  padding: .35em .6em;
+}
+
+/* Botón de procedencia centrado */
+.procedencia-cell{ text-align: center; }
+
+/* Grids multicolumna de checkboxes */
 .options-grid .form-check{
-  display:flex;
-  align-items:center;
+  display: flex;
+  align-items: center;
 }
 
 /* [login] Ajuste para el botón del toggle de contraseña */
 .input-group .btn{min-width:2.5rem;}
-/* [checklist] estilos login ajustados */

--- a/src/views/layouts/layout.ejs
+++ b/src/views/layouts/layout.ejs
@@ -10,17 +10,18 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= title ? title + ' — ' : '' %>Inventario</title>
-      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-      <%- include('../partials/head') %>
-      <link rel="stylesheet" href="/css/styles.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"><!-- Bootstrap base -->
+    <%- include('../partials/head') %><!-- Librerías externas: Boxicons, SweetAlert2 -->
+    <link rel="stylesheet" href="/resources/css/styles.css"><!-- Estilos propios -->
   </head>
   <body>
-    <%- include('../partials/header') %>
-    <main class="container mt-4 <%= (typeof viewClass !== 'undefined' && viewClass) ? viewClass : '' %>">
+    <%- include('../partials/header') %><!-- Navbar y saludo de usuario -->
+    <div class="navbar-spacer"></div><!-- Separador para que el contenido no pegue a la barra -->
+    <main class="container <%= (typeof viewClass !== 'undefined' && viewClass) ? viewClass : '' %>"><!-- Contenido principal -->
       <%- body %>
     </main>
-    <%- include('../partials/footer') %>
-    <% if (flash) { %>
+    <%- include('../partials/footer') %><!-- Pie de página -->
+    <% if (flash) { %><!-- Mensajes flash con SweetAlert2 -->
       <script>
         Swal.fire({
           icon: '<%= flash.type === "success" ? "success" : "error" %>',

--- a/src/views/pages/panel.ejs
+++ b/src/views/pages/panel.ejs
@@ -1,78 +1,73 @@
+<!-- Resumen general del inventario -->
 <h1 class="mb-4">Resumen</h1>
-<div class="row g-3">
+<div class="row g-3"><!-- Grid de tarjetas resumen -->
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100 summary-card border-brand">
+    <div class="card card-summary bg-primary text-white text-center">
       <div class="card-body">
-        <i class="tile-icon text-brand <%= icons.productos %>"></i>
-        <p class="display-6"><%= counts.productos %></p>
-        <p class="text-muted mb-0">Productos</p>
+        <i class="<%= icons.productos %> summary-icon"></i>
+        <p class="summary-value"><%= counts.productos %></p>
+        <p class="mb-0">Productos</p>
         <a href="/productos" class="stretched-link" aria-label="Ir a productos"></a>
       </div>
     </div>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100 summary-card border-accent">
+    <div class="card card-summary bg-success text-white text-center">
       <div class="card-body">
-        <i class="tile-icon text-accent <%= icons.categorias %>"></i>
-        <p class="display-6"><%= counts.categorias %></p>
-        <p class="text-muted mb-0">Categorías</p>
+        <i class="<%= icons.categorias %> summary-icon"></i>
+        <p class="summary-value"><%= counts.categorias %></p>
+        <p class="mb-0">Categorías</p>
         <a href="/categorias" class="stretched-link" aria-label="Ir a categorías"></a>
       </div>
     </div>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100 summary-card border-muted">
+    <div class="card card-summary bg-warning text-white text-center">
       <div class="card-body">
-        <svg class="tile-icon text-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <rect x="1" y="7" width="13" height="8" rx="2" ry="2"></rect>
-          <path d="M14 9h4l3 3v3h-7z"></path>
-          <circle cx="5.5" cy="18" r="1.5"></circle>
-          <circle cx="17.5" cy="18" r="1.5"></circle>
-        </svg>
-        <p class="display-6"><%= counts.proveedores %></p>
-        <p class="text-muted mb-0">Proveedores</p>
+        <i class="<%= icons.proveedores %> summary-icon"></i>
+        <p class="summary-value"><%= counts.proveedores %></p>
+        <p class="mb-0">Proveedores</p>
         <a href="/proveedores" class="stretched-link" aria-label="Ir a proveedores"></a>
       </div>
     </div>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100 summary-card border-success">
+    <div class="card card-summary bg-info text-white text-center">
       <div class="card-body">
-        <i class="tile-icon text-success <%= icons.localizaciones %>"></i>
-        <p class="display-6"><%= counts.localizaciones %></p>
-        <p class="text-muted mb-0">Localizaciones</p>
+        <i class="<%= icons.localizaciones %> summary-icon"></i>
+        <p class="summary-value"><%= counts.localizaciones %></p>
+        <p class="mb-0">Localizaciones</p>
         <a href="/localizaciones" class="stretched-link" aria-label="Ir a localizaciones"></a>
       </div>
     </div>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card text-center h-100 summary-card border-warning">
+    <div class="card card-summary bg-danger text-white text-center">
       <div class="card-body">
-        <i class="tile-icon text-warning <%= icons.bajoStock %>"></i>
-        <p class="display-6"><%= counts.bajoStock %></p>
-        <p class="text-muted mb-0">Bajo stock</p>
-        <!-- Tarjeta enlaza al listado filtrado de productos con stock bajo -->
+        <i class="<%= icons.bajoStock %> summary-icon"></i>
+        <p class="summary-value"><%= counts.bajoStock %></p>
+        <p class="mb-0">Bajo stock</p>
         <a class="stretched-link" href="/bajo-stock" aria-label="Ir a Bajo stock"></a>
       </div>
     </div>
   </div>
   <% if (isAdmin) { %>
     <div class="col-6 col-md-4 col-lg-2">
-      <div class="card text-center h-100 summary-card border-brand">
+      <div class="card card-summary bg-secondary text-white text-center">
         <div class="card-body">
-          <i class="tile-icon text-brand <%= icons.usuarios %>"></i>
-          <p class="display-6"><%= counts.usuarios %></p>
-          <p class="text-muted mb-0">Usuarios</p>
+          <i class="<%= icons.usuarios %> summary-icon"></i>
+          <p class="summary-value"><%= counts.usuarios %></p>
+          <p class="mb-0">Usuarios</p>
           <a href="/usuarios" class="stretched-link" aria-label="Ir a usuarios"></a>
         </div>
       </div>
     </div>
     <div class="col-6 col-md-4 col-lg-2">
-      <div class="card text-center h-100 summary-card border-danger">
+      <div class="card card-summary bg-dark text-white text-center">
         <div class="card-body">
-          <i class="tile-icon text-danger <%= icons.admins %>"></i>
-          <p class="display-6"><%= counts.admins %></p>
-          <p class="text-muted mb-0">Admins</p>
+          <i class="<%= icons.admins %> summary-icon"></i>
+          <p class="summary-value"><%= counts.admins %></p>
+          <p class="mb-0">Admins</p>
           <a href="/usuarios" class="stretched-link" aria-label="Ir a usuarios"></a>
         </div>
       </div>

--- a/src/views/pages/productos/bajoStock.ejs
+++ b/src/views/pages/productos/bajoStock.ejs
@@ -1,7 +1,5 @@
 <%# Listado de productos con stock bajo. Similar a list.ejs pero sin acciones de edición/eliminación. %>
 <h1>Bajo stock</h1>
-<!-- Botón para regresar a la vista que nos llamó; cae al panel si no se especifica -->
-<a href="<%= returnTo || '/panel' %>" class="btn btn-secondary mb-3">Volver</a>
 <button class="btn btn-outline-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#searchBox">Buscar</button>
 <div id="searchBox" class="collapse"><!-- Contenedor plegable de filtros -->
   <% if (errors && errors.length) { %>
@@ -118,13 +116,18 @@
         <td><%= p.nombre %></td>
         <td><%= p.precio %></td>
         <td><%= p.costo %></td>
-        <td><%= p.stock %></td>
+        <td>
+          <span><%= p.stock %></span>
+          <% if (p.stock <= p.stock_minimo) { %>
+            <span class="badge badge-lowstock ms-2">Bajo stock</span>
+          <% } %>
+        </td>
         <td><%= p.stock_minimo %></td>
         <td class="procedencia-cell">
           <% const cats = p.categorias.length ? p.categorias.map(c=>c.nombre).join(', ') : '—';
              const provs = p.proveedores.length ? p.proveedores.map(pr=>pr.nombre).join(', ') : '—'; %>
           <button type="button" class="btn btn-sm btn-outline-secondary procedencia-btn" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="left" data-bs-html="true" title="Procedencia" data-bs-content="<strong>Categorías:</strong> <%= cats %><br><strong>Proveedores:</strong> <%= provs %>">
-            <i class="bx bx-info-circle" aria-hidden="true"></i><span class="visually-hidden">Ver procedencia</span>
+            <i class="bx bx-info-circle icon-inline" aria-hidden="true"></i><span class="visually-hidden">Ver procedencia</span>
           </button>
         </td>
         <td><%= p.localizacion || '-' %></td>

--- a/src/views/pages/productos/detail.ejs
+++ b/src/views/pages/productos/detail.ejs
@@ -1,14 +1,16 @@
 <%# Detalle de producto; muestra imagen o placeholder elegante %>
 <div class="row">
   <div class="col-md-8"><%# Columna izquierda: texto %>
-    <div class="d-flex align-items-center gap-2 mb-3">
-      <h1 class="mb-0"><%= producto.nombre %></h1>
-      <% if (isBajoStock) { %><span class="badge badge-bajo-stock">Bajo stock</span><% } %>
-    </div>
+    <h1 class="mb-3"><%= producto.nombre %></h1>
     <p><strong>Descripción:</strong> <%= producto.descripcion || '-' %></p>
     <p><strong>Precio:</strong> <%= producto.precio %></p>
     <p><strong>Costo:</strong> <%= producto.costo %></p>
-    <p><strong>Stock:</strong> <%= producto.stock %></p>
+    <p><strong>Stock:</strong>
+      <span><%= producto.stock %></span>
+      <% if (isBajoStock) { %>
+        <span class="badge badge-lowstock ms-2">Bajo stock</span>
+      <% } %>
+    </p>
     <p><strong>Stock mín.:</strong> <%= producto.stock_minimo %></p>
     <% const cats = producto.categorias.length ? producto.categorias.map(c=>c.nombre).join(', ') : '—';
        const provs = producto.proveedores.length ? producto.proveedores.map(p=>p.nombre).join(', ') : '—'; %>

--- a/src/views/pages/productos/list.ejs
+++ b/src/views/pages/productos/list.ejs
@@ -121,28 +121,33 @@
   </thead>
   <tbody>
     <% productos.forEach(p => { %>
-      <tr class="<%= p.stock < p.stock_minimo ? 'table-warning' : '' %>">
+      <tr class="<%= p.stock <= p.stock_minimo ? 'table-warning' : '' %>">
         <td><%= p.id %></td>
         <td><%= p.nombre %></td>
         <td><%= p.precio %></td>
         <td><%= p.costo %></td>
-        <td><%= p.stock %> <% if (p.stock < p.stock_minimo) { %><span class="badge badge-bajo-stock">Bajo stock</span><% } %></td>
+        <td>
+          <span><%= p.stock %></span>
+          <% if (p.stock <= p.stock_minimo) { %>
+            <span class="badge badge-lowstock ms-2">Bajo stock</span>
+          <% } %>
+        </td>
         <td><%= p.stock_minimo %></td>
         <td>
           <% if (p.descripcion) { %>
-            <i class='bx bx-info-circle' data-bs-toggle="tooltip" title="<%= p.descripcion %>"></i>
+            <i class='bx bx-info-circle icon-inline' data-bs-toggle="tooltip" title="<%= p.descripcion %>"></i>
           <% } %>
         </td>
         <td>
           <% if (p.observaciones) { %>
-            <i class='bx bx-info-circle' data-bs-toggle="tooltip" title="<%= p.observaciones %>"></i>
+            <i class='bx bx-info-circle icon-inline' data-bs-toggle="tooltip" title="<%= p.observaciones %>"></i>
           <% } %>
         </td>
         <td class="procedencia-cell">
           <% const cats = p.categorias.length ? p.categorias.map(c=>c.nombre).join(', ') : '—';
              const provs = p.proveedores.length ? p.proveedores.map(pr=>pr.nombre).join(', ') : '—'; %>
           <button type="button" class="btn btn-sm btn-outline-secondary procedencia-btn" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="left" data-bs-html="true" title="Procedencia" data-bs-content="<strong>Categorías:</strong> <%= cats %><br><strong>Proveedores:</strong> <%= provs %>">
-            <i class="bx bx-info-circle" aria-hidden="true"></i><span class="visually-hidden">Ver procedencia</span>
+            <i class="bx bx-info-circle icon-inline" aria-hidden="true"></i><span class="visually-hidden">Ver procedencia</span>
           </button>
         </td>
         <td><%= p.localizacion || '-' %></td>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -5,21 +5,21 @@
       <a class="navbar-brand" href="/">Inventario</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"><span class="navbar-toggler-icon"></span></button>
       <div class="collapse navbar-collapse nav-separated" id="navbarNav">
+        <% const path = typeof activePath !== 'undefined' ? activePath : currentPath; %>
         <% if (isAuthenticated) { %>
           <div class="navbar-identity d-lg-none mb-2">👋 Hola, <strong><%= userName %></strong> (<%= userRole %>)</div>
         <% } %>
         <!-- Menú principal: enlaces a secciones del inventario -->
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
           <% if (isAuthenticated) { %>
-              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/panel') ? 'active' : '' %>" href="/panel">Panel</a></li>
-              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/productos') ? 'active' : '' %>" href="/productos">Productos</a></li>
-              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/categorias') ? 'active' : '' %>" href="/categorias">Categorías</a></li>
-              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/proveedores') ? 'active' : '' %>" href="/proveedores">Proveedores</a></li>
-              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/localizaciones') ? 'active' : '' %>" href="/localizaciones">Localizaciones</a></li>
-              <!-- Acceso rápido al listado de productos con stock bajo -->
-              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/bajo-stock') ? 'active' : '' %>" href="/bajo-stock">Bajo stock</a></li>
+            <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= path.startsWith('/panel') ? 'active' : '' %>" href="/panel" <%= path.startsWith('/panel') ? 'aria-current="page"' : '' %>>Inicio</a></li>
+            <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= path.startsWith('/productos') ? 'active' : '' %>" href="/productos" <%= path.startsWith('/productos') ? 'aria-current="page"' : '' %>>Productos</a></li>
+            <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= path.startsWith('/bajo-stock') ? 'active' : '' %>" href="/bajo-stock" <%= path.startsWith('/bajo-stock') ? 'aria-current="page"' : '' %>>Bajo stock</a></li>
+            <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= path.startsWith('/categorias') ? 'active' : '' %>" href="/categorias" <%= path.startsWith('/categorias') ? 'aria-current="page"' : '' %>>Categorías</a></li>
+            <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= path.startsWith('/proveedores') ? 'active' : '' %>" href="/proveedores" <%= path.startsWith('/proveedores') ? 'aria-current="page"' : '' %>>Proveedores</a></li>
+            <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= path.startsWith('/localizaciones') ? 'active' : '' %>" href="/localizaciones" <%= path.startsWith('/localizaciones') ? 'aria-current="page"' : '' %>>Localizaciones</a></li>
             <% if (userRole === 'admin') { %>
-                <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath.startsWith('/usuarios') ? 'active' : '' %>" href="/usuarios">Usuarios</a></li>
+              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= path.startsWith('/usuarios') ? 'active' : '' %>" href="/usuarios" <%= path.startsWith('/usuarios') ? 'aria-current="page"' : '' %>>Usuarios</a></li>
             <% } %>
           <% } %>
         </ul>
@@ -27,9 +27,9 @@
         <ul class="navbar-nav">
           <% if (isAuthenticated) { %>
             <li class="nav-item d-none d-lg-block"><span class="navbar-text me-3">👋 Hola, <strong><%= userName %></strong> (<%= userRole %>)</span></li>
-              <li class="nav-item"><a class="nav-link ps-3 ms-3" href="/auth/logout">Salir</a></li>
+            <li class="nav-item"><a class="nav-link ps-3 ms-3" href="/auth/logout">Salir</a></li>
           <% } else { %>
-              <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= currentPath === '/login' ? 'active' : '' %>" href="/login">Login</a></li>
+            <li class="nav-item"><a class="nav-link ps-3 ms-3 <%= path === '/login' ? 'active' : '' %>" href="/login" <%= path === '/login' ? 'aria-current="page"' : '' %>>Login</a></li>
           <% } %>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- restore top spacing and active state for navigation links
- unify dashboard cards and icon sizes
- show red "Bajo stock" badge next to stock values and remove return button from low stock view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1ae564120832aa41c03e08b9c9203