### PR TITLE
chore: remix visual y badges de stock

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,12 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 - Navegación returnTo sigue funcionando tras crear/editar/eliminar.
 
 ### Pruebas manuales de UI
-- Navbar con espacio superior y enlace activo resaltado.
-- Panel: todas las tarjetas mismos tamaños, iconos a ~1.75rem, colores Bootstrap.
-- Productos: badge rojo ‘Bajo stock’ junto a stock cuando stock <= stock_minimo.
-- Bajo stock: sin botón ‘Volver’; listado correcto.
-- Proveedores: icono tamaño normal (no gigante).
+- Navbar: hay espacio superior (spacer) y el enlace activo se ve resaltado (fondo/borde).
+- Panel: todas las tarjetas mismo alto, iconos ~1.75rem, colores contextuales y toda la tarjeta es clicable.
+- Productos (lista): si stock <= stock_minimo, se ve badge roja “Bajo stock” junto al número.
+- Detalle: imagen con borde redondeado y sombra; si no hay imagen, placeholder “Sin imagen”.
+- Bajo stock: vista accesible desde navbar y desde el panel; sin botón “Volver”.
+- Iconos (categorías/proveedores/localizaciones) nunca gigantes; respetan .icon-inline.
 
 ## Troubleshooting
 - **DB access denied**: revisa credenciales y privilegios MySQL.
@@ -234,6 +235,8 @@ Las páginas de detalle incluyen `returnTo` para regresar a la vista previa.
 - **Errores al importar seeds**: asegúrate de que la base existe y de tener permisos.
 
 ## CHANGELOG
+## [2025-09-10 21:00] – Remix visual consolidado
+- Remix de estilos: navbar con respiración y activo visible; panel con tarjetas uniformes; badge “Bajo stock” restaurada; iconos dimensionados.
 ## [2025-09-10 20:00] – Ajustes de UI
 - Restaurado espaciado de navbar y estado activo en navegación.
 - Tarjetas del panel uniformes con colores consistentes e iconos a tamaño correcto.

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1,66 +1,65 @@
-/* Escala y variables base */
+/* Remix de estilos: variables y utilidades comunes */
 :root{
-  /* Paleta base (puedes ajustar si el proyecto tenía otra) */
-  --space-1: .5rem;
-  --space-2: 1rem;
-  --space-3: 1.5rem;
-  --radius-lg: 1rem;
-  --shadow-1: 0 2px 10px rgba(0,0,0,.06);
-  --brand-active-bg: #e7f1ff; /* azul muy suave para activo */
-  --brand-active-border: #b6d3ff;
-  --danger-strong: #dc3545;  /* Bootstrap danger */
+  --space-1:.5rem; --space-2:1rem; --space-3:1.5rem;
+  --radius-md:.75rem; --radius-lg:1rem;
+  --shadow-1:0 2px 10px rgba(0,0,0,.06);
+  --shadow-2:0 6px 22px rgba(0,0,0,.08);
+  --active-bg:#e7f1ff; --active-border:#b6d3ff;
+  --brand-muted:#6c757d; --danger:#dc3545;
+  --card-min-h:140px;
 }
 
-/* Espacio bajo navbar para que no “pegue” al borde superior */
-.navbar-spacer{ height: var(--space-2); }
+/* Espaciador que da “respiración” debajo de la navbar */
+.navbar-spacer{height:var(--space-2);}
 
-/* Estado activo del enlace de navegación */
+/* Enlace activo y estados accesibles en la navegación */
 .navbar .nav-link.active{
-  background: var(--brand-active-bg);
-  border: 1px solid var(--brand-active-border);
-  border-radius: var(--radius-lg);
+  background:var(--active-bg);
+  border:1px solid var(--active-border);
+  border-radius:var(--radius-md);
 }
+.navbar .nav-link:hover:not(.active){background:rgba(0,0,0,.05);}
+.navbar .nav-link:focus-visible{outline:2px solid var(--active-border);outline-offset:2px;}
 
-/* Tarjetas de resumen del panel */
+/* Tarjetas de resumen del panel: tamaño y tipografía uniformes */
 .card-summary{
-  min-height: 140px;             /* uniformidad */
-  border: none;
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-1);
+  min-height:var(--card-min-h);
+  border:none;
+  border-radius:var(--radius-lg);
+  box-shadow:var(--shadow-1);
 }
-.card-summary .summary-icon{
-  font-size: 1.75rem;            /* iconos consistentes */
-  opacity: .9;
-}
-.card-summary .summary-value{
-  font-size: 1.8rem;
-  font-weight: 700;
-  line-height: 1;
-}
+.card-summary .summary-icon{font-size:1.75rem;opacity:.9;}
+.card-summary .summary-value{font-size:1.8rem;font-weight:700;line-height:1;}
 
-/* Iconos embebidos en tablas (categorías, proveedores, etc.) */
-.icon-inline{
-  font-size: 1rem;
-  vertical-align: middle;
-}
+/* Iconos en tablas/listas: tamaño contenido y alineados */
+.icon-inline{font-size:1rem;vertical-align:middle;}
 
-/* Badge de bajo stock coherente y legible */
+/* Badge roja para indicar bajo stock */
 .badge-lowstock{
-  background: var(--danger-strong);
-  color: #fff;
-  border-radius: .5rem;
-  font-weight: 600;
-  padding: .35em .6em;
+  background:var(--danger);
+  color:#fff;
+  border-radius:.5rem;
+  font-weight:600;
+  padding:.35em .6em;
 }
 
-/* Botón de procedencia centrado */
-.procedencia-cell{ text-align: center; }
+/* Tablas con mejor alineación vertical */
+.table td,.table th{vertical-align:middle;}
 
-/* Grids multicolumna de checkboxes */
-.options-grid .form-check{
-  display: flex;
-  align-items: center;
+/* Imagen o placeholder en detalle de producto */
+.product-media{box-shadow:var(--shadow-2);border-radius:var(--radius-lg);}
+.placeholder-img{
+  min-height:220px;
+  border:1px dashed #ced4da;
+  border-radius:var(--radius-md);
+  color:var(--brand-muted);
 }
 
-/* [login] Ajuste para el botón del toggle de contraseña */
+/* Celdas de procedencia centradas */
+.procedencia-cell{text-align:center;}
+
+/* Grids multicolumna para listas de checkboxes */
+.options-grid .form-check{display:flex;align-items:center;}
+
+/* Ajuste para botón de toggle de contraseña */
 .input-group .btn{min-width:2.5rem;}

--- a/src/views/pages/panel.ejs
+++ b/src/views/pages/panel.ejs
@@ -1,76 +1,70 @@
 <!-- Resumen general del inventario -->
 <h1 class="mb-4">Resumen</h1>
 <div class="row g-3"><!-- Grid de tarjetas resumen -->
+  <!-- Cada tarjeta es un enlace completo con icono y contador -->
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card card-summary bg-primary text-white text-center">
+    <a href="/productos" class="card card-summary bg-primary text-white text-center text-decoration-none">
       <div class="card-body">
         <i class="<%= icons.productos %> summary-icon"></i>
         <p class="summary-value"><%= counts.productos %></p>
         <p class="mb-0">Productos</p>
-        <a href="/productos" class="stretched-link" aria-label="Ir a productos"></a>
       </div>
-    </div>
+    </a>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card card-summary bg-success text-white text-center">
+    <a href="/categorias" class="card card-summary bg-success text-white text-center text-decoration-none">
       <div class="card-body">
         <i class="<%= icons.categorias %> summary-icon"></i>
         <p class="summary-value"><%= counts.categorias %></p>
         <p class="mb-0">Categorías</p>
-        <a href="/categorias" class="stretched-link" aria-label="Ir a categorías"></a>
       </div>
-    </div>
+    </a>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card card-summary bg-warning text-white text-center">
+    <a href="/proveedores" class="card card-summary bg-warning text-white text-center text-decoration-none">
       <div class="card-body">
         <i class="<%= icons.proveedores %> summary-icon"></i>
         <p class="summary-value"><%= counts.proveedores %></p>
         <p class="mb-0">Proveedores</p>
-        <a href="/proveedores" class="stretched-link" aria-label="Ir a proveedores"></a>
       </div>
-    </div>
+    </a>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card card-summary bg-info text-white text-center">
+    <a href="/localizaciones" class="card card-summary bg-info text-white text-center text-decoration-none">
       <div class="card-body">
         <i class="<%= icons.localizaciones %> summary-icon"></i>
         <p class="summary-value"><%= counts.localizaciones %></p>
         <p class="mb-0">Localizaciones</p>
-        <a href="/localizaciones" class="stretched-link" aria-label="Ir a localizaciones"></a>
       </div>
-    </div>
+    </a>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <div class="card card-summary bg-danger text-white text-center">
+    <a href="/bajo-stock" class="card card-summary bg-danger text-white text-center text-decoration-none">
       <div class="card-body">
         <i class="<%= icons.bajoStock %> summary-icon"></i>
         <p class="summary-value"><%= counts.bajoStock %></p>
         <p class="mb-0">Bajo stock</p>
-        <a class="stretched-link" href="/bajo-stock" aria-label="Ir a Bajo stock"></a>
       </div>
-    </div>
+    </a>
   </div>
   <% if (isAdmin) { %>
     <div class="col-6 col-md-4 col-lg-2">
-      <div class="card card-summary bg-secondary text-white text-center">
+      <a href="/usuarios" class="card card-summary bg-secondary text-white text-center text-decoration-none">
         <div class="card-body">
           <i class="<%= icons.usuarios %> summary-icon"></i>
           <p class="summary-value"><%= counts.usuarios %></p>
           <p class="mb-0">Usuarios</p>
-          <a href="/usuarios" class="stretched-link" aria-label="Ir a usuarios"></a>
         </div>
-      </div>
+      </a>
     </div>
     <div class="col-6 col-md-4 col-lg-2">
-      <div class="card card-summary bg-dark text-white text-center">
+      <a href="/usuarios" class="card card-summary bg-dark text-white text-center text-decoration-none">
         <div class="card-body">
           <i class="<%= icons.admins %> summary-icon"></i>
           <p class="summary-value"><%= counts.admins %></p>
           <p class="mb-0">Admins</p>
-          <a href="/usuarios" class="stretched-link" aria-label="Ir a usuarios"></a>
         </div>
-      </div>
+      </a>
     </div>
   <% } %>
 </div>

--- a/src/views/pages/productos/detail.ejs
+++ b/src/views/pages/productos/detail.ejs
@@ -24,9 +24,9 @@
   </div>
   <div class="col-md-4"><%# Columna derecha: imagen o placeholder %>
     <% if (imageUrl) { %>
-      <img src="<%= imageUrl %>" alt="Imagen de <%= producto.nombre %>" class="img-fluid rounded shadow-sm">
+      <img src="<%= imageUrl %>" alt="Imagen de <%= producto.nombre %>" class="img-fluid product-media">
     <% } else { %>
-      <div class="border rounded d-flex align-items-center justify-content-center p-4 text-muted" style="min-height:220px">
+      <div class="placeholder-img d-flex align-items-center justify-content-center p-4">
         <i class="bx bx-image-alt fs-1 me-2" aria-hidden="true"></i> <span>Sin imagen</span>
       </div>
     <% } %>


### PR DESCRIPTION
## Summary
- unifica variables y estados activos en estilos, con tarjetas uniformes y badge de bajo stock
- tarjetas del panel clicables y detalle de producto con placeholder elegante
- documentación con changelog y pruebas manuales de UI

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1c625fb44832a83816e594ced4ec6